### PR TITLE
renaming variable 'async' to 'async_http_request'

### DIFF
--- a/vplexapi-7.0.0.0/vplexapi/api/aggregate_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/aggregate_api.py
@@ -37,11 +37,11 @@ class AggregateApi(object):
         """Groups the resources at the given URI by the values of the provided fields and returns aggregated computations for each group   # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_aggregates(uri, group_by, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_aggregates(uri, group_by, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str uri: URI of collection to aggregate (required)
         :param str group_by: Comma-separated list of fields to aggregate on (required)
         :return: Aggregates
@@ -49,7 +49,7 @@ class AggregateApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_aggregates_with_http_info(uri, group_by, **kwargs)  # noqa: E501
         else:
             (data) = self.get_aggregates_with_http_info(uri, group_by, **kwargs)  # noqa: E501
@@ -59,11 +59,11 @@ class AggregateApi(object):
         """Groups the resources at the given URI by the values of the provided fields and returns aggregated computations for each group   # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_aggregates_with_http_info(uri, group_by, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_aggregates_with_http_info(uri, group_by, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str uri: URI of collection to aggregate (required)
         :param str group_by: Comma-separated list of fields to aggregate on (required)
         :return: Aggregates
@@ -72,7 +72,7 @@ class AggregateApi(object):
         """
 
         all_params = ['uri', 'group_by']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -124,7 +124,7 @@ class AggregateApi(object):
             files=local_var_files,
             response_type='Aggregates',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/amp_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/amp_api.py
@@ -37,11 +37,11 @@ class AmpApi(object):
         """Returns the details of an AMP  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_array_management_provider(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_array_management_provider(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
@@ -50,7 +50,7 @@ class AmpApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_array_management_provider_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_array_management_provider_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class AmpApi(object):
         """Returns the details of an AMP  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_array_management_provider_with_http_info(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_array_management_provider_with_http_info(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
@@ -74,7 +74,7 @@ class AmpApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -128,7 +128,7 @@ class AmpApi(object):
             files=local_var_files,
             response_type='ArrayManagementProvider',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -138,11 +138,11 @@ class AmpApi(object):
         """Returns a list of registered AMPs  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_array_management_providers(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_array_management_providers(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
         :param int limit: <p>Maximum number of elements to include in paginated results.<br> <b>'offset' must also be specified.<b>
@@ -154,7 +154,7 @@ class AmpApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_array_management_providers_with_http_info(cluster_name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_array_management_providers_with_http_info(cluster_name, **kwargs)  # noqa: E501
@@ -164,11 +164,11 @@ class AmpApi(object):
         """Returns a list of registered AMPs  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_array_management_providers_with_http_info(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_array_management_providers_with_http_info(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
         :param int limit: <p>Maximum number of elements to include in paginated results.<br> <b>'offset' must also be specified.<b>
@@ -181,7 +181,7 @@ class AmpApi(object):
         """
 
         all_params = ['cluster_name', 'offset', 'limit', 'sort_by', 'fields', 'connectivity_status']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -243,7 +243,7 @@ class AmpApi(object):
             files=local_var_files,
             response_type='list[ArrayManagementProvider]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -253,11 +253,11 @@ class AmpApi(object):
         """Register a new ArrayManagementProvider  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.register_array_management_provider(cluster_name, amp_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.register_array_management_provider(cluster_name, amp_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param AmpPayload amp_payload: (required)
         :return: ArrayManagementProvider
@@ -265,7 +265,7 @@ class AmpApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.register_array_management_provider_with_http_info(cluster_name, amp_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.register_array_management_provider_with_http_info(cluster_name, amp_payload, **kwargs)  # noqa: E501
@@ -275,11 +275,11 @@ class AmpApi(object):
         """Register a new ArrayManagementProvider  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.register_array_management_provider_with_http_info(cluster_name, amp_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.register_array_management_provider_with_http_info(cluster_name, amp_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param AmpPayload amp_payload: (required)
         :return: ArrayManagementProvider
@@ -288,7 +288,7 @@ class AmpApi(object):
         """
 
         all_params = ['cluster_name', 'amp_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -340,7 +340,7 @@ class AmpApi(object):
             files=local_var_files,
             response_type='ArrayManagementProvider',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -350,11 +350,11 @@ class AmpApi(object):
         """Unregisters an AMP  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.unregister_array_management_provider(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.unregister_array_management_provider(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: None
@@ -362,7 +362,7 @@ class AmpApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.unregister_array_management_provider_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.unregister_array_management_provider_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
@@ -372,11 +372,11 @@ class AmpApi(object):
         """Unregisters an AMP  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.unregister_array_management_provider_with_http_info(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.unregister_array_management_provider_with_http_info(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: None
@@ -385,7 +385,7 @@ class AmpApi(object):
         """
 
         all_params = ['cluster_name', 'name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -437,7 +437,7 @@ class AmpApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/bulk_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/bulk_api.py
@@ -37,18 +37,18 @@ class BulkApi(object):
         """Make a bulk request  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.bulk_request(request, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.bulk_request(request, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param object request: (required)
         :return: BulkResponse
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.bulk_request_with_http_info(request, **kwargs)  # noqa: E501
         else:
             (data) = self.bulk_request_with_http_info(request, **kwargs)  # noqa: E501
@@ -58,11 +58,11 @@ class BulkApi(object):
         """Make a bulk request  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.bulk_request_with_http_info(request, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.bulk_request_with_http_info(request, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param object request: (required)
         :return: BulkResponse
                  If the method is called asynchronously,
@@ -70,7 +70,7 @@ class BulkApi(object):
         """
 
         all_params = ['request']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -116,7 +116,7 @@ class BulkApi(object):
             files=local_var_files,
             response_type='BulkResponse',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/certificates_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/certificates_api.py
@@ -37,11 +37,11 @@ class CertificatesApi(object):
         """Add the certificate to the keystore.  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_certificate(external_certificate, certificate_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.add_certificate(external_certificate, certificate_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str external_certificate: The IP:PORT of system associated with this certificate. (required)
         :param CertificatePayload certificate_payload: (required)
         :return: Certificate
@@ -49,7 +49,7 @@ class CertificatesApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.add_certificate_with_http_info(external_certificate, certificate_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.add_certificate_with_http_info(external_certificate, certificate_payload, **kwargs)  # noqa: E501
@@ -59,11 +59,11 @@ class CertificatesApi(object):
         """Add the certificate to the keystore.  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.add_certificate_with_http_info(external_certificate, certificate_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.add_certificate_with_http_info(external_certificate, certificate_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str external_certificate: The IP:PORT of system associated with this certificate. (required)
         :param CertificatePayload certificate_payload: (required)
         :return: Certificate
@@ -72,7 +72,7 @@ class CertificatesApi(object):
         """
 
         all_params = ['external_certificate', 'certificate_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -132,7 +132,7 @@ class CertificatesApi(object):
             files=local_var_files,
             response_type='Certificate',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -142,18 +142,18 @@ class CertificatesApi(object):
         """Fetches the SSL Certificate of an external system  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.external_certificates_untrusted_external_certificate_get(external_certificate, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.external_certificates_untrusted_external_certificate_get(external_certificate, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str external_certificate: The IP:PORT of system associated with this certificate. (required)
         :return: Certificate
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.external_certificates_untrusted_external_certificate_get_with_http_info(external_certificate, **kwargs)  # noqa: E501
         else:
             (data) = self.external_certificates_untrusted_external_certificate_get_with_http_info(external_certificate, **kwargs)  # noqa: E501
@@ -163,11 +163,11 @@ class CertificatesApi(object):
         """Fetches the SSL Certificate of an external system  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.external_certificates_untrusted_external_certificate_get_with_http_info(external_certificate, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.external_certificates_untrusted_external_certificate_get_with_http_info(external_certificate, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str external_certificate: The IP:PORT of system associated with this certificate. (required)
         :return: Certificate
                  If the method is called asynchronously,
@@ -175,7 +175,7 @@ class CertificatesApi(object):
         """
 
         all_params = ['external_certificate']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -225,7 +225,7 @@ class CertificatesApi(object):
             files=local_var_files,
             response_type='Certificate',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -235,18 +235,18 @@ class CertificatesApi(object):
         """Fetch the certificate from the keystore.  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_trusted_certificate(external_certificate, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_trusted_certificate(external_certificate, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str external_certificate: The IP:PORT of system associated with this certificate. (required)
         :return: Certificate
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_trusted_certificate_with_http_info(external_certificate, **kwargs)  # noqa: E501
         else:
             (data) = self.get_trusted_certificate_with_http_info(external_certificate, **kwargs)  # noqa: E501
@@ -256,11 +256,11 @@ class CertificatesApi(object):
         """Fetch the certificate from the keystore.  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_trusted_certificate_with_http_info(external_certificate, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_trusted_certificate_with_http_info(external_certificate, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str external_certificate: The IP:PORT of system associated with this certificate. (required)
         :return: Certificate
                  If the method is called asynchronously,
@@ -268,7 +268,7 @@ class CertificatesApi(object):
         """
 
         all_params = ['external_certificate']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -318,7 +318,7 @@ class CertificatesApi(object):
             files=local_var_files,
             response_type='Certificate',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -328,18 +328,18 @@ class CertificatesApi(object):
         """Remove the certificate from the keystore.  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.remove_certificate(external_certificate, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.remove_certificate(external_certificate, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str external_certificate: The IP:PORT of system associated with this certificate. (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.remove_certificate_with_http_info(external_certificate, **kwargs)  # noqa: E501
         else:
             (data) = self.remove_certificate_with_http_info(external_certificate, **kwargs)  # noqa: E501
@@ -349,11 +349,11 @@ class CertificatesApi(object):
         """Remove the certificate from the keystore.  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.remove_certificate_with_http_info(external_certificate, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.remove_certificate_with_http_info(external_certificate, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str external_certificate: The IP:PORT of system associated with this certificate. (required)
         :return: None
                  If the method is called asynchronously,
@@ -361,7 +361,7 @@ class CertificatesApi(object):
         """
 
         all_params = ['external_certificate']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -407,7 +407,7 @@ class CertificatesApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/cluster_witness_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/cluster_witness_api.py
@@ -38,17 +38,17 @@ class ClusterWitnessApi(object):
 
         Cluster witness can't be deleted if its currently enabled.   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_cluster_witness(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_cluster_witness(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.delete_cluster_witness_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.delete_cluster_witness_with_http_info(**kwargs)  # noqa: E501
@@ -59,18 +59,18 @@ class ClusterWitnessApi(object):
 
         Cluster witness can't be deleted if its currently enabled.   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_cluster_witness_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_cluster_witness_with_http_info(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
         all_params = []  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -110,7 +110,7 @@ class ClusterWitnessApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -120,17 +120,17 @@ class ClusterWitnessApi(object):
         """Return the cluster witness wired to the system  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_cluster_witness(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_cluster_witness(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :return: ClusterWitness
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_cluster_witness_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_cluster_witness_with_http_info(**kwargs)  # noqa: E501
@@ -140,18 +140,18 @@ class ClusterWitnessApi(object):
         """Return the cluster witness wired to the system  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_cluster_witness_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_cluster_witness_with_http_info(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :return: ClusterWitness
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
         all_params = []  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -191,7 +191,7 @@ class ClusterWitnessApi(object):
             files=local_var_files,
             response_type='ClusterWitness',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -202,18 +202,18 @@ class ClusterWitnessApi(object):
 
         Settable attributes are 'admin state'   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_cluster_witness(clusterwitness_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_cluster_witness(clusterwitness_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param list[JsonPatchOp] clusterwitness_patch_payload: (required)
         :return: ClusterWitness
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.patch_cluster_witness_with_http_info(clusterwitness_patch_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.patch_cluster_witness_with_http_info(clusterwitness_patch_payload, **kwargs)  # noqa: E501
@@ -224,11 +224,11 @@ class ClusterWitnessApi(object):
 
         Settable attributes are 'admin state'   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_cluster_witness_with_http_info(clusterwitness_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_cluster_witness_with_http_info(clusterwitness_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param list[JsonPatchOp] clusterwitness_patch_payload: (required)
         :return: ClusterWitness
                  If the method is called asynchronously,
@@ -236,7 +236,7 @@ class ClusterWitnessApi(object):
         """
 
         all_params = ['clusterwitness_patch_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -282,7 +282,7 @@ class ClusterWitnessApi(object):
             files=local_var_files,
             response_type='ClusterWitness',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/clusters_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/clusters_api.py
@@ -37,11 +37,11 @@ class ClustersApi(object):
         """Return a Cluster matching the provided name  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_cluster(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_cluster(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
         :return: Cluster
@@ -49,7 +49,7 @@ class ClustersApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_cluster_with_http_info(cluster_name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_cluster_with_http_info(cluster_name, **kwargs)  # noqa: E501
@@ -59,11 +59,11 @@ class ClustersApi(object):
         """Return a Cluster matching the provided name  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_cluster_with_http_info(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_cluster_with_http_info(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
         :return: Cluster
@@ -72,7 +72,7 @@ class ClustersApi(object):
         """
 
         all_params = ['cluster_name', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -120,7 +120,7 @@ class ClustersApi(object):
             files=local_var_files,
             response_type='Cluster',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -130,11 +130,11 @@ class ClustersApi(object):
         """Returns a list of the available clusters  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_clusters(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_clusters(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
         :param int limit: <p>Maximum number of elements to include in paginated results.<br> <b>'offset' must also be specified.<b>
         :param str sort_by: Specify the field priority order and direction for sorting.  See SortingOrderExpression for details. 
@@ -145,7 +145,7 @@ class ClustersApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_clusters_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_clusters_with_http_info(**kwargs)  # noqa: E501
@@ -155,11 +155,11 @@ class ClustersApi(object):
         """Returns a list of the available clusters  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_clusters_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_clusters_with_http_info(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
         :param int limit: <p>Maximum number of elements to include in paginated results.<br> <b>'offset' must also be specified.<b>
         :param str sort_by: Specify the field priority order and direction for sorting.  See SortingOrderExpression for details. 
@@ -171,7 +171,7 @@ class ClustersApi(object):
         """
 
         all_params = ['offset', 'limit', 'sort_by', 'fields', 'cluster_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -227,7 +227,7 @@ class ClustersApi(object):
             files=local_var_files,
             response_type='list[Cluster]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -238,11 +238,11 @@ class ClustersApi(object):
 
         Settable attributes are 'name' and 'allow_auto_join'   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_cluster(cluster_name, cluster_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_cluster(cluster_name, cluster_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param list[JsonPatchOp] cluster_patch_payload: (required)
         :return: Cluster
@@ -250,7 +250,7 @@ class ClustersApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.patch_cluster_with_http_info(cluster_name, cluster_patch_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.patch_cluster_with_http_info(cluster_name, cluster_patch_payload, **kwargs)  # noqa: E501
@@ -261,11 +261,11 @@ class ClustersApi(object):
 
         Settable attributes are 'name' and 'allow_auto_join'   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_cluster_with_http_info(cluster_name, cluster_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_cluster_with_http_info(cluster_name, cluster_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param list[JsonPatchOp] cluster_patch_payload: (required)
         :return: Cluster
@@ -274,7 +274,7 @@ class ClustersApi(object):
         """
 
         all_params = ['cluster_name', 'cluster_patch_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -326,7 +326,7 @@ class ClustersApi(object):
             files=local_var_files,
             response_type='Cluster',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/consistency_group_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/consistency_group_api.py
@@ -37,11 +37,11 @@ class ConsistencyGroupApi(object):
         """Create a new ConsistencyGroup  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_consistency_group(cluster_name, consistency_group_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.create_consistency_group(cluster_name, consistency_group_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param ConsistencyGroupPayload consistency_group_payload: (required)
         :param str x_include_object: When passed as part of a POST request, controls whether the representation of the newly created object is included in the response. Defaults to 'true' which will include the object in the response. This header is useful because refreshing the newly created object is usually the slowest part of a POST operation. 
@@ -50,7 +50,7 @@ class ConsistencyGroupApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.create_consistency_group_with_http_info(cluster_name, consistency_group_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.create_consistency_group_with_http_info(cluster_name, consistency_group_payload, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ConsistencyGroupApi(object):
         """Create a new ConsistencyGroup  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_consistency_group_with_http_info(cluster_name, consistency_group_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.create_consistency_group_with_http_info(cluster_name, consistency_group_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param ConsistencyGroupPayload consistency_group_payload: (required)
         :param str x_include_object: When passed as part of a POST request, controls whether the representation of the newly created object is included in the response. Defaults to 'true' which will include the object in the response. This header is useful because refreshing the newly created object is usually the slowest part of a POST operation. 
@@ -74,7 +74,7 @@ class ConsistencyGroupApi(object):
         """
 
         all_params = ['cluster_name', 'consistency_group_payload', 'x_include_object']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -128,7 +128,7 @@ class ConsistencyGroupApi(object):
             files=local_var_files,
             response_type='ConsistencyGroup',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -138,11 +138,11 @@ class ConsistencyGroupApi(object):
         """Deletes a single ConsistencyGroup  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_consistency_group(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_consistency_group(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: None
@@ -150,7 +150,7 @@ class ConsistencyGroupApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.delete_consistency_group_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_consistency_group_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class ConsistencyGroupApi(object):
         """Deletes a single ConsistencyGroup  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_consistency_group_with_http_info(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_consistency_group_with_http_info(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: None
@@ -173,7 +173,7 @@ class ConsistencyGroupApi(object):
         """
 
         all_params = ['cluster_name', 'name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -225,7 +225,7 @@ class ConsistencyGroupApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -235,11 +235,11 @@ class ConsistencyGroupApi(object):
         """Returns a single ConsistencyGroup object  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_consistency_group(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_consistency_group(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
@@ -248,7 +248,7 @@ class ConsistencyGroupApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_consistency_group_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_consistency_group_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
@@ -258,11 +258,11 @@ class ConsistencyGroupApi(object):
         """Returns a single ConsistencyGroup object  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_consistency_group_with_http_info(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_consistency_group_with_http_info(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
@@ -272,7 +272,7 @@ class ConsistencyGroupApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -326,7 +326,7 @@ class ConsistencyGroupApi(object):
             files=local_var_files,
             response_type='ConsistencyGroup',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -336,11 +336,11 @@ class ConsistencyGroupApi(object):
         """Returns a list of ConsistencyGroups  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_consistency_groups(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_consistency_groups(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: Filter results by name. See LexicalQueryExpression for details.
         :param str operational_status: Filter results by operational_status. See LexicalQueryExpression for details.
@@ -353,7 +353,7 @@ class ConsistencyGroupApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_consistency_groups_with_http_info(cluster_name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_consistency_groups_with_http_info(cluster_name, **kwargs)  # noqa: E501
@@ -363,11 +363,11 @@ class ConsistencyGroupApi(object):
         """Returns a list of ConsistencyGroups  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_consistency_groups_with_http_info(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_consistency_groups_with_http_info(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: Filter results by name. See LexicalQueryExpression for details.
         :param str operational_status: Filter results by operational_status. See LexicalQueryExpression for details.
@@ -381,7 +381,7 @@ class ConsistencyGroupApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'operational_status', 'offset', 'limit', 'sort_by', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -449,7 +449,7 @@ class ConsistencyGroupApi(object):
             files=local_var_files,
             response_type='list[ConsistencyGroup]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -460,11 +460,11 @@ class ConsistencyGroupApi(object):
 
         Patchable attributes:   * detach_rule (replace)     * {\"type\": winner\", \"cluster\": <cluster_uri>, \"delay\": <delay_in_seconds>}     * {\"type\": \"no_automatic_winner\"}   * name (replace)   * storage_at_clusters (add/remove)   * virtual_volumes (add/remove)   * visibility (add/remove)   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_consistency_group(cluster_name, name, consistency_group_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_consistency_group(cluster_name, name, consistency_group_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param list[JsonPatchOp] consistency_group_patch_payload: (required)
@@ -473,7 +473,7 @@ class ConsistencyGroupApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.patch_consistency_group_with_http_info(cluster_name, name, consistency_group_patch_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.patch_consistency_group_with_http_info(cluster_name, name, consistency_group_patch_payload, **kwargs)  # noqa: E501
@@ -484,11 +484,11 @@ class ConsistencyGroupApi(object):
 
         Patchable attributes:   * detach_rule (replace)     * {\"type\": winner\", \"cluster\": <cluster_uri>, \"delay\": <delay_in_seconds>}     * {\"type\": \"no_automatic_winner\"}   * name (replace)   * storage_at_clusters (add/remove)   * virtual_volumes (add/remove)   * visibility (add/remove)   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_consistency_group_with_http_info(cluster_name, name, consistency_group_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_consistency_group_with_http_info(cluster_name, name, consistency_group_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param list[JsonPatchOp] consistency_group_patch_payload: (required)
@@ -498,7 +498,7 @@ class ConsistencyGroupApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'consistency_group_patch_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -556,7 +556,7 @@ class ConsistencyGroupApi(object):
             files=local_var_files,
             response_type='ConsistencyGroup',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/data_migration_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/data_migration_api.py
@@ -37,18 +37,18 @@ class DataMigrationApi(object):
         """Create a new DeviceMigration  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_device_migration(device_migration_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.create_device_migration(device_migration_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param DeviceMigrationPayload device_migration_payload: (required)
         :return: DeviceMigration
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.create_device_migration_with_http_info(device_migration_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.create_device_migration_with_http_info(device_migration_payload, **kwargs)  # noqa: E501
@@ -58,11 +58,11 @@ class DataMigrationApi(object):
         """Create a new DeviceMigration  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_device_migration_with_http_info(device_migration_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.create_device_migration_with_http_info(device_migration_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param DeviceMigrationPayload device_migration_payload: (required)
         :return: DeviceMigration
                  If the method is called asynchronously,
@@ -70,7 +70,7 @@ class DataMigrationApi(object):
         """
 
         all_params = ['device_migration_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -116,7 +116,7 @@ class DataMigrationApi(object):
             files=local_var_files,
             response_type='DeviceMigration',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -126,18 +126,18 @@ class DataMigrationApi(object):
         """Create a new ExtentMigration  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_extent_migration(extent_migration_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.create_extent_migration(extent_migration_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param ExtentMigrationPayload extent_migration_payload: (required)
         :return: ExtentMigration
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.create_extent_migration_with_http_info(extent_migration_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.create_extent_migration_with_http_info(extent_migration_payload, **kwargs)  # noqa: E501
@@ -147,11 +147,11 @@ class DataMigrationApi(object):
         """Create a new ExtentMigration  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_extent_migration_with_http_info(extent_migration_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.create_extent_migration_with_http_info(extent_migration_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param ExtentMigrationPayload extent_migration_payload: (required)
         :return: ExtentMigration
                  If the method is called asynchronously,
@@ -159,7 +159,7 @@ class DataMigrationApi(object):
         """
 
         all_params = ['extent_migration_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -205,7 +205,7 @@ class DataMigrationApi(object):
             files=local_var_files,
             response_type='ExtentMigration',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -215,18 +215,18 @@ class DataMigrationApi(object):
         """Deletes a single canceled or committed DeviceMigration  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_device_migration(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_device_migration(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.delete_device_migration_with_http_info(name, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_device_migration_with_http_info(name, **kwargs)  # noqa: E501
@@ -236,11 +236,11 @@ class DataMigrationApi(object):
         """Deletes a single canceled or committed DeviceMigration  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_device_migration_with_http_info(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_device_migration_with_http_info(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :return: None
                  If the method is called asynchronously,
@@ -248,7 +248,7 @@ class DataMigrationApi(object):
         """
 
         all_params = ['name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -294,7 +294,7 @@ class DataMigrationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -304,18 +304,18 @@ class DataMigrationApi(object):
         """Deletes a single canceled or committed ExtentMigration  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_extent_migration(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_extent_migration(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.delete_extent_migration_with_http_info(name, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_extent_migration_with_http_info(name, **kwargs)  # noqa: E501
@@ -325,11 +325,11 @@ class DataMigrationApi(object):
         """Deletes a single canceled or committed ExtentMigration  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_extent_migration_with_http_info(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_extent_migration_with_http_info(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :return: None
                  If the method is called asynchronously,
@@ -337,7 +337,7 @@ class DataMigrationApi(object):
         """
 
         all_params = ['name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -383,7 +383,7 @@ class DataMigrationApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -393,11 +393,11 @@ class DataMigrationApi(object):
         """Returns a single DeviceMigration object  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_device_migration(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_device_migration(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
         :return: DeviceMigration
@@ -405,7 +405,7 @@ class DataMigrationApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_device_migration_with_http_info(name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_device_migration_with_http_info(name, **kwargs)  # noqa: E501
@@ -415,11 +415,11 @@ class DataMigrationApi(object):
         """Returns a single DeviceMigration object  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_device_migration_with_http_info(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_device_migration_with_http_info(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
         :return: DeviceMigration
@@ -428,7 +428,7 @@ class DataMigrationApi(object):
         """
 
         all_params = ['name', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -476,7 +476,7 @@ class DataMigrationApi(object):
             files=local_var_files,
             response_type='DeviceMigration',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -486,11 +486,11 @@ class DataMigrationApi(object):
         """Returns a list of device migrations  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_device_migrations(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_device_migrations(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: Filter results by name. See LexicalQueryExpression for details.
         :param str to_cluster: Filter results by to_cluster. See LexicalQueryExpression for details.
         :param str from_cluster: Filter results by from_cluster. See LexicalQueryExpression for details.
@@ -503,7 +503,7 @@ class DataMigrationApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_device_migrations_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_device_migrations_with_http_info(**kwargs)  # noqa: E501
@@ -513,11 +513,11 @@ class DataMigrationApi(object):
         """Returns a list of device migrations  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_device_migrations_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_device_migrations_with_http_info(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: Filter results by name. See LexicalQueryExpression for details.
         :param str to_cluster: Filter results by to_cluster. See LexicalQueryExpression for details.
         :param str from_cluster: Filter results by from_cluster. See LexicalQueryExpression for details.
@@ -531,7 +531,7 @@ class DataMigrationApi(object):
         """
 
         all_params = ['name', 'to_cluster', 'from_cluster', 'offset', 'limit', 'sort_by', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -591,7 +591,7 @@ class DataMigrationApi(object):
             files=local_var_files,
             response_type='list[DeviceMigration]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -601,11 +601,11 @@ class DataMigrationApi(object):
         """Returns a single ExtentMigration object  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_extent_migration(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_extent_migration(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
         :return: ExtentMigration
@@ -613,7 +613,7 @@ class DataMigrationApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_extent_migration_with_http_info(name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_extent_migration_with_http_info(name, **kwargs)  # noqa: E501
@@ -623,11 +623,11 @@ class DataMigrationApi(object):
         """Returns a single ExtentMigration object  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_extent_migration_with_http_info(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_extent_migration_with_http_info(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
         :return: ExtentMigration
@@ -636,7 +636,7 @@ class DataMigrationApi(object):
         """
 
         all_params = ['name', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -684,7 +684,7 @@ class DataMigrationApi(object):
             files=local_var_files,
             response_type='ExtentMigration',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -694,11 +694,11 @@ class DataMigrationApi(object):
         """Returns a list of extent migrations  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_extent_migrations(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_extent_migrations(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: Filter results by name. See LexicalQueryExpression for details.
         :param str to_cluster: Filter results by to_cluster. See LexicalQueryExpression for details.
         :param str from_cluster: Filter results by from_cluster. See LexicalQueryExpression for details.
@@ -711,7 +711,7 @@ class DataMigrationApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_extent_migrations_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_extent_migrations_with_http_info(**kwargs)  # noqa: E501
@@ -721,11 +721,11 @@ class DataMigrationApi(object):
         """Returns a list of extent migrations  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_extent_migrations_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_extent_migrations_with_http_info(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: Filter results by name. See LexicalQueryExpression for details.
         :param str to_cluster: Filter results by to_cluster. See LexicalQueryExpression for details.
         :param str from_cluster: Filter results by from_cluster. See LexicalQueryExpression for details.
@@ -739,7 +739,7 @@ class DataMigrationApi(object):
         """
 
         all_params = ['name', 'to_cluster', 'from_cluster', 'offset', 'limit', 'sort_by', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -799,7 +799,7 @@ class DataMigrationApi(object):
             files=local_var_files,
             response_type='list[ExtentMigration]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -810,11 +810,11 @@ class DataMigrationApi(object):
 
         Settable attributes: 'name', 'transfer_size' and 'status'(replace)   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_device_migration(name, device_migration_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_device_migration(name, device_migration_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :param list[JsonPatchOp] device_migration_patch_payload: (required)
         :return: DeviceMigration
@@ -822,7 +822,7 @@ class DataMigrationApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.patch_device_migration_with_http_info(name, device_migration_patch_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.patch_device_migration_with_http_info(name, device_migration_patch_payload, **kwargs)  # noqa: E501
@@ -833,11 +833,11 @@ class DataMigrationApi(object):
 
         Settable attributes: 'name', 'transfer_size' and 'status'(replace)   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_device_migration_with_http_info(name, device_migration_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_device_migration_with_http_info(name, device_migration_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :param list[JsonPatchOp] device_migration_patch_payload: (required)
         :return: DeviceMigration
@@ -846,7 +846,7 @@ class DataMigrationApi(object):
         """
 
         all_params = ['name', 'device_migration_patch_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -898,7 +898,7 @@ class DataMigrationApi(object):
             files=local_var_files,
             response_type='DeviceMigration',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -909,11 +909,11 @@ class DataMigrationApi(object):
 
         Settable attributes: 'name', 'transfer_size' and 'status'(replace)   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_extent_migration(name, extent_migration_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_extent_migration(name, extent_migration_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :param list[JsonPatchOp] extent_migration_patch_payload: (required)
         :return: ExtentMigration
@@ -921,7 +921,7 @@ class DataMigrationApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.patch_extent_migration_with_http_info(name, extent_migration_patch_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.patch_extent_migration_with_http_info(name, extent_migration_patch_payload, **kwargs)  # noqa: E501
@@ -932,11 +932,11 @@ class DataMigrationApi(object):
 
         Settable attributes: 'name', 'transfer_size' and 'status'(replace)   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_extent_migration_with_http_info(name, extent_migration_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_extent_migration_with_http_info(name, extent_migration_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :param list[JsonPatchOp] extent_migration_patch_payload: (required)
         :return: ExtentMigration
@@ -945,7 +945,7 @@ class DataMigrationApi(object):
         """
 
         all_params = ['name', 'extent_migration_patch_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -997,7 +997,7 @@ class DataMigrationApi(object):
             files=local_var_files,
             response_type='ExtentMigration',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/devices_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/devices_api.py
@@ -37,11 +37,11 @@ class DevicesApi(object):
         """Create a new Device  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_device(cluster_name, device_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.create_device(cluster_name, device_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param DevicePayload device_payload: (required)
         :param str x_include_object: When passed as part of a POST request, controls whether the representation of the newly created object is included in the response. Defaults to 'true' which will include the object in the response. This header is useful because refreshing the newly created object is usually the slowest part of a POST operation. 
@@ -50,7 +50,7 @@ class DevicesApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.create_device_with_http_info(cluster_name, device_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.create_device_with_http_info(cluster_name, device_payload, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class DevicesApi(object):
         """Create a new Device  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_device_with_http_info(cluster_name, device_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.create_device_with_http_info(cluster_name, device_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param DevicePayload device_payload: (required)
         :param str x_include_object: When passed as part of a POST request, controls whether the representation of the newly created object is included in the response. Defaults to 'true' which will include the object in the response. This header is useful because refreshing the newly created object is usually the slowest part of a POST operation. 
@@ -74,7 +74,7 @@ class DevicesApi(object):
         """
 
         all_params = ['cluster_name', 'device_payload', 'x_include_object']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -128,7 +128,7 @@ class DevicesApi(object):
             files=local_var_files,
             response_type='Device',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -138,11 +138,11 @@ class DevicesApi(object):
         """Deletes a single Device  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_device(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_device(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: None
@@ -150,7 +150,7 @@ class DevicesApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.delete_device_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_device_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class DevicesApi(object):
         """Deletes a single Device  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_device_with_http_info(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_device_with_http_info(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: None
@@ -173,7 +173,7 @@ class DevicesApi(object):
         """
 
         all_params = ['cluster_name', 'name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -225,7 +225,7 @@ class DevicesApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -235,11 +235,11 @@ class DevicesApi(object):
         """Returns a single Device object  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_device(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_device(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
@@ -248,7 +248,7 @@ class DevicesApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_device_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_device_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
@@ -258,11 +258,11 @@ class DevicesApi(object):
         """Returns a single Device object  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_device_with_http_info(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_device_with_http_info(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
@@ -272,7 +272,7 @@ class DevicesApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -326,7 +326,7 @@ class DevicesApi(object):
             files=local_var_files,
             response_type='Device',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -336,11 +336,11 @@ class DevicesApi(object):
         """Returns a list of Device objects  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_devices(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_devices(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: Filter results by name. See LexicalQueryExpression for details.
         :param str capacity: Filter results by capacity.  See NumericQueryExpression for details.
@@ -359,7 +359,7 @@ class DevicesApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_devices_with_http_info(cluster_name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_devices_with_http_info(cluster_name, **kwargs)  # noqa: E501
@@ -369,11 +369,11 @@ class DevicesApi(object):
         """Returns a list of Device objects  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_devices_with_http_info(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_devices_with_http_info(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: Filter results by name. See LexicalQueryExpression for details.
         :param str capacity: Filter results by capacity.  See NumericQueryExpression for details.
@@ -393,7 +393,7 @@ class DevicesApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'capacity', 'virtual_volume', 'visibility', 'top_level', 'thin_capable', 'operational_status', 'health_state', 'offset', 'limit', 'sort_by', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -469,7 +469,7 @@ class DevicesApi(object):
             files=local_var_files,
             response_type='list[Device]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -480,11 +480,11 @@ class DevicesApi(object):
 
         Patchable operations:   * name   * transfer_size   * attach_operation_payload     * {\"op\": \"add\", \"path\": \"/legs\", \"value\": <device_uri>}     * {\"op\": \"add\", \"path\": \"/legs\", \"value\": <extent_uri>}   * detach_operation_payload     * {\"op\": \"remove\", \"path\": \"/legs\", \"value\": <device_uri>}     * {\"op\": \"remove\", \"path\": \"/legs\", \"value\": <extent_uri>}   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_local_device(cluster_name, name, local_device_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_local_device(cluster_name, name, local_device_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: (required)
         :param list[JsonPatchOp] local_device_patch_payload: (required)
@@ -493,7 +493,7 @@ class DevicesApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.patch_local_device_with_http_info(cluster_name, name, local_device_patch_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.patch_local_device_with_http_info(cluster_name, name, local_device_patch_payload, **kwargs)  # noqa: E501
@@ -504,11 +504,11 @@ class DevicesApi(object):
 
         Patchable operations:   * name   * transfer_size   * attach_operation_payload     * {\"op\": \"add\", \"path\": \"/legs\", \"value\": <device_uri>}     * {\"op\": \"add\", \"path\": \"/legs\", \"value\": <extent_uri>}   * detach_operation_payload     * {\"op\": \"remove\", \"path\": \"/legs\", \"value\": <device_uri>}     * {\"op\": \"remove\", \"path\": \"/legs\", \"value\": <extent_uri>}   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_local_device_with_http_info(cluster_name, name, local_device_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_local_device_with_http_info(cluster_name, name, local_device_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: (required)
         :param list[JsonPatchOp] local_device_patch_payload: (required)
@@ -518,7 +518,7 @@ class DevicesApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'local_device_patch_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -576,7 +576,7 @@ class DevicesApi(object):
             files=local_var_files,
             response_type='Device',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/director_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/director_api.py
@@ -37,11 +37,11 @@ class DirectorApi(object):
         """Return a Director matching the provided name  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_director(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_director(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
         :return: Director
@@ -49,7 +49,7 @@ class DirectorApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_director_with_http_info(name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_director_with_http_info(name, **kwargs)  # noqa: E501
@@ -59,11 +59,11 @@ class DirectorApi(object):
         """Return a Director matching the provided name  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_director_with_http_info(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_director_with_http_info(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
         :return: Director
@@ -72,7 +72,7 @@ class DirectorApi(object):
         """
 
         all_params = ['name', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -120,7 +120,7 @@ class DirectorApi(object):
             files=local_var_files,
             response_type='Director',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -130,11 +130,11 @@ class DirectorApi(object):
         """Returns a list of the available directors  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_directors(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_directors(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
         :param int limit: <p>Maximum number of elements to include in paginated results.<br> <b>'offset' must also be specified.<b>
         :param str sort_by: Specify the field priority order and direction for sorting.  See SortingOrderExpression for details. 
@@ -147,7 +147,7 @@ class DirectorApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_directors_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_directors_with_http_info(**kwargs)  # noqa: E501
@@ -157,11 +157,11 @@ class DirectorApi(object):
         """Returns a list of the available directors  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_directors_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_directors_with_http_info(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
         :param int limit: <p>Maximum number of elements to include in paginated results.<br> <b>'offset' must also be specified.<b>
         :param str sort_by: Specify the field priority order and direction for sorting.  See SortingOrderExpression for details. 
@@ -175,7 +175,7 @@ class DirectorApi(object):
         """
 
         all_params = ['offset', 'limit', 'sort_by', 'fields', 'health_state', 'operational_status', 'cluster_id']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -235,7 +235,7 @@ class DirectorApi(object):
             files=local_var_files,
             response_type='list[Director]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/director_ports_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/director_ports_api.py
@@ -37,11 +37,11 @@ class DirectorPortsApi(object):
         """Returns a single DirectorPort object  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_director_port(director_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_director_port(director_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str director_name: The name of the director (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: DirectorPort
@@ -49,7 +49,7 @@ class DirectorPortsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_director_port_with_http_info(director_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_director_port_with_http_info(director_name, name, **kwargs)  # noqa: E501
@@ -59,11 +59,11 @@ class DirectorPortsApi(object):
         """Returns a single DirectorPort object  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_director_port_with_http_info(director_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_director_port_with_http_info(director_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str director_name: The name of the director (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: DirectorPort
@@ -72,7 +72,7 @@ class DirectorPortsApi(object):
         """
 
         all_params = ['director_name', 'name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -124,7 +124,7 @@ class DirectorPortsApi(object):
             files=local_var_files,
             response_type='DirectorPort',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -134,18 +134,18 @@ class DirectorPortsApi(object):
         """Returns a list of director ports  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_director_ports(director_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_director_ports(director_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str director_name: The name of the director (required)
         :return: list[DirectorPort]
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_director_ports_with_http_info(director_name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_director_ports_with_http_info(director_name, **kwargs)  # noqa: E501
@@ -155,11 +155,11 @@ class DirectorPortsApi(object):
         """Returns a list of director ports  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_director_ports_with_http_info(director_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_director_ports_with_http_info(director_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str director_name: The name of the director (required)
         :return: list[DirectorPort]
                  If the method is called asynchronously,
@@ -167,7 +167,7 @@ class DirectorPortsApi(object):
         """
 
         all_params = ['director_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -213,7 +213,7 @@ class DirectorPortsApi(object):
             files=local_var_files,
             response_type='list[DirectorPort]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -224,11 +224,11 @@ class DirectorPortsApi(object):
 
         Settable attribute is 'enabled'   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_director_port(director_name, name, port_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_director_port(director_name, name, port_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str director_name: The name of the director (required)
         :param str name: The name of a specific instance of the resource (required)
         :param list[JsonPatchOp] port_patch_payload: (required)
@@ -237,7 +237,7 @@ class DirectorPortsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.patch_director_port_with_http_info(director_name, name, port_patch_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.patch_director_port_with_http_info(director_name, name, port_patch_payload, **kwargs)  # noqa: E501
@@ -248,11 +248,11 @@ class DirectorPortsApi(object):
 
         Settable attribute is 'enabled'   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_director_port_with_http_info(director_name, name, port_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_director_port_with_http_info(director_name, name, port_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str director_name: The name of the director (required)
         :param str name: The name of a specific instance of the resource (required)
         :param list[JsonPatchOp] port_patch_payload: (required)
@@ -262,7 +262,7 @@ class DirectorPortsApi(object):
         """
 
         all_params = ['director_name', 'name', 'port_patch_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -320,7 +320,7 @@ class DirectorPortsApi(object):
             files=local_var_files,
             response_type='DirectorPort',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/distributed_storage_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/distributed_storage_api.py
@@ -37,11 +37,11 @@ class DistributedStorageApi(object):
         """Create a new distributed ConsistencyGroup  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_distributed_consistency_group(distributed_consistency_group_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.create_distributed_consistency_group(distributed_consistency_group_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param DistributedConsistencyGroupPayload distributed_consistency_group_payload: (required)
         :param str x_include_object: When passed as part of a POST request, controls whether the representation of the newly created object is included in the response. Defaults to 'true' which will include the object in the response. This header is useful because refreshing the newly created object is usually the slowest part of a POST operation. 
         :return: ConsistencyGroup
@@ -49,7 +49,7 @@ class DistributedStorageApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.create_distributed_consistency_group_with_http_info(distributed_consistency_group_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.create_distributed_consistency_group_with_http_info(distributed_consistency_group_payload, **kwargs)  # noqa: E501
@@ -59,11 +59,11 @@ class DistributedStorageApi(object):
         """Create a new distributed ConsistencyGroup  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_distributed_consistency_group_with_http_info(distributed_consistency_group_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.create_distributed_consistency_group_with_http_info(distributed_consistency_group_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param DistributedConsistencyGroupPayload distributed_consistency_group_payload: (required)
         :param str x_include_object: When passed as part of a POST request, controls whether the representation of the newly created object is included in the response. Defaults to 'true' which will include the object in the response. This header is useful because refreshing the newly created object is usually the slowest part of a POST operation. 
         :return: ConsistencyGroup
@@ -72,7 +72,7 @@ class DistributedStorageApi(object):
         """
 
         all_params = ['distributed_consistency_group_payload', 'x_include_object']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -120,7 +120,7 @@ class DistributedStorageApi(object):
             files=local_var_files,
             response_type='ConsistencyGroup',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -130,11 +130,11 @@ class DistributedStorageApi(object):
         """Create a new DistributedDevice  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_distributed_device(distributed_device_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.create_distributed_device(distributed_device_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param DistributedDevicePayload distributed_device_payload: (required)
         :param str x_include_object: When passed as part of a POST request, controls whether the representation of the newly created object is included in the response. Defaults to 'true' which will include the object in the response. This header is useful because refreshing the newly created object is usually the slowest part of a POST operation. 
         :return: DistributedDevice
@@ -142,7 +142,7 @@ class DistributedStorageApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.create_distributed_device_with_http_info(distributed_device_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.create_distributed_device_with_http_info(distributed_device_payload, **kwargs)  # noqa: E501
@@ -152,11 +152,11 @@ class DistributedStorageApi(object):
         """Create a new DistributedDevice  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_distributed_device_with_http_info(distributed_device_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.create_distributed_device_with_http_info(distributed_device_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param DistributedDevicePayload distributed_device_payload: (required)
         :param str x_include_object: When passed as part of a POST request, controls whether the representation of the newly created object is included in the response. Defaults to 'true' which will include the object in the response. This header is useful because refreshing the newly created object is usually the slowest part of a POST operation. 
         :return: DistributedDevice
@@ -165,7 +165,7 @@ class DistributedStorageApi(object):
         """
 
         all_params = ['distributed_device_payload', 'x_include_object']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -213,7 +213,7 @@ class DistributedStorageApi(object):
             files=local_var_files,
             response_type='DistributedDevice',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -223,11 +223,11 @@ class DistributedStorageApi(object):
         """Create a new distributed VirtualVolume  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_distributed_virtual_volume(distributed_virtual_volume_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.create_distributed_virtual_volume(distributed_virtual_volume_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param DistributedVirtualVolumePayload distributed_virtual_volume_payload: (required)
         :param str x_include_object: When passed as part of a POST request, controls whether the representation of the newly created object is included in the response. Defaults to 'true' which will include the object in the response. This header is useful because refreshing the newly created object is usually the slowest part of a POST operation. 
         :return: VirtualVolume
@@ -235,7 +235,7 @@ class DistributedStorageApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.create_distributed_virtual_volume_with_http_info(distributed_virtual_volume_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.create_distributed_virtual_volume_with_http_info(distributed_virtual_volume_payload, **kwargs)  # noqa: E501
@@ -245,11 +245,11 @@ class DistributedStorageApi(object):
         """Create a new distributed VirtualVolume  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_distributed_virtual_volume_with_http_info(distributed_virtual_volume_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.create_distributed_virtual_volume_with_http_info(distributed_virtual_volume_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param DistributedVirtualVolumePayload distributed_virtual_volume_payload: (required)
         :param str x_include_object: When passed as part of a POST request, controls whether the representation of the newly created object is included in the response. Defaults to 'true' which will include the object in the response. This header is useful because refreshing the newly created object is usually the slowest part of a POST operation. 
         :return: VirtualVolume
@@ -258,7 +258,7 @@ class DistributedStorageApi(object):
         """
 
         all_params = ['distributed_virtual_volume_payload', 'x_include_object']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -306,7 +306,7 @@ class DistributedStorageApi(object):
             files=local_var_files,
             response_type='VirtualVolume',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -316,18 +316,18 @@ class DistributedStorageApi(object):
         """Deletes a single distributed ConsistencyGroup  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_distributed_consistency_group(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_distributed_consistency_group(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.delete_distributed_consistency_group_with_http_info(name, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_distributed_consistency_group_with_http_info(name, **kwargs)  # noqa: E501
@@ -337,11 +337,11 @@ class DistributedStorageApi(object):
         """Deletes a single distributed ConsistencyGroup  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_distributed_consistency_group_with_http_info(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_distributed_consistency_group_with_http_info(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :return: None
                  If the method is called asynchronously,
@@ -349,7 +349,7 @@ class DistributedStorageApi(object):
         """
 
         all_params = ['name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -395,7 +395,7 @@ class DistributedStorageApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -405,18 +405,18 @@ class DistributedStorageApi(object):
         """Deletes a single DistributedDevice  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_distributed_device(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_distributed_device(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.delete_distributed_device_with_http_info(name, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_distributed_device_with_http_info(name, **kwargs)  # noqa: E501
@@ -426,11 +426,11 @@ class DistributedStorageApi(object):
         """Deletes a single DistributedDevice  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_distributed_device_with_http_info(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_distributed_device_with_http_info(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :return: None
                  If the method is called asynchronously,
@@ -438,7 +438,7 @@ class DistributedStorageApi(object):
         """
 
         all_params = ['name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -484,7 +484,7 @@ class DistributedStorageApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -494,18 +494,18 @@ class DistributedStorageApi(object):
         """Deletes a single distributed VirtualVolume  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_distributed_virtual_volume(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_distributed_virtual_volume(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.delete_distributed_virtual_volume_with_http_info(name, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_distributed_virtual_volume_with_http_info(name, **kwargs)  # noqa: E501
@@ -515,11 +515,11 @@ class DistributedStorageApi(object):
         """Deletes a single distributed VirtualVolume  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_distributed_virtual_volume_with_http_info(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_distributed_virtual_volume_with_http_info(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :return: None
                  If the method is called asynchronously,
@@ -527,7 +527,7 @@ class DistributedStorageApi(object):
         """
 
         all_params = ['name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -573,7 +573,7 @@ class DistributedStorageApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -583,11 +583,11 @@ class DistributedStorageApi(object):
         """Expand the capacity of a distributed VirtualVolume  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.expand_distributed_virtual_volume(name, distributed_virtual_volume_expand_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.expand_distributed_virtual_volume(name, distributed_virtual_volume_expand_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :param DistributedVirtualVolumeExpandPayload distributed_virtual_volume_expand_payload: (required)
         :return: VirtualVolume
@@ -595,7 +595,7 @@ class DistributedStorageApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.expand_distributed_virtual_volume_with_http_info(name, distributed_virtual_volume_expand_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.expand_distributed_virtual_volume_with_http_info(name, distributed_virtual_volume_expand_payload, **kwargs)  # noqa: E501
@@ -605,11 +605,11 @@ class DistributedStorageApi(object):
         """Expand the capacity of a distributed VirtualVolume  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.expand_distributed_virtual_volume_with_http_info(name, distributed_virtual_volume_expand_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.expand_distributed_virtual_volume_with_http_info(name, distributed_virtual_volume_expand_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :param DistributedVirtualVolumeExpandPayload distributed_virtual_volume_expand_payload: (required)
         :return: VirtualVolume
@@ -618,7 +618,7 @@ class DistributedStorageApi(object):
         """
 
         all_params = ['name', 'distributed_virtual_volume_expand_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -670,7 +670,7 @@ class DistributedStorageApi(object):
             files=local_var_files,
             response_type='VirtualVolume',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -680,18 +680,18 @@ class DistributedStorageApi(object):
         """Returns a single distributed ConsistencyGroup object  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_distributed_consistency_group(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_distributed_consistency_group(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :return: ConsistencyGroup
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_distributed_consistency_group_with_http_info(name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_distributed_consistency_group_with_http_info(name, **kwargs)  # noqa: E501
@@ -701,11 +701,11 @@ class DistributedStorageApi(object):
         """Returns a single distributed ConsistencyGroup object  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_distributed_consistency_group_with_http_info(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_distributed_consistency_group_with_http_info(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :return: ConsistencyGroup
                  If the method is called asynchronously,
@@ -713,7 +713,7 @@ class DistributedStorageApi(object):
         """
 
         all_params = ['name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -759,7 +759,7 @@ class DistributedStorageApi(object):
             files=local_var_files,
             response_type='ConsistencyGroup',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -769,11 +769,11 @@ class DistributedStorageApi(object):
         """Returns a list of distributed ConsistencyGroups  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_distributed_consistency_groups(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_distributed_consistency_groups(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
         :param int limit: <p>Maximum number of elements to include in paginated results.<br> <b>'offset' must also be specified.<b>
         :param str name: Filter results by name. See LexicalQueryExpression for details.
@@ -785,7 +785,7 @@ class DistributedStorageApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_distributed_consistency_groups_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_distributed_consistency_groups_with_http_info(**kwargs)  # noqa: E501
@@ -795,11 +795,11 @@ class DistributedStorageApi(object):
         """Returns a list of distributed ConsistencyGroups  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_distributed_consistency_groups_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_distributed_consistency_groups_with_http_info(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
         :param int limit: <p>Maximum number of elements to include in paginated results.<br> <b>'offset' must also be specified.<b>
         :param str name: Filter results by name. See LexicalQueryExpression for details.
@@ -812,7 +812,7 @@ class DistributedStorageApi(object):
         """
 
         all_params = ['offset', 'limit', 'name', 'operational_status', 'sort_by', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -870,7 +870,7 @@ class DistributedStorageApi(object):
             files=local_var_files,
             response_type='list[ConsistencyGroup]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -880,11 +880,11 @@ class DistributedStorageApi(object):
         """Returns a single DistributedDevice object  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_distributed_device(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_distributed_device(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
         :return: DistributedDevice
@@ -892,7 +892,7 @@ class DistributedStorageApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_distributed_device_with_http_info(name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_distributed_device_with_http_info(name, **kwargs)  # noqa: E501
@@ -902,11 +902,11 @@ class DistributedStorageApi(object):
         """Returns a single DistributedDevice object  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_distributed_device_with_http_info(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_distributed_device_with_http_info(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
         :return: DistributedDevice
@@ -915,7 +915,7 @@ class DistributedStorageApi(object):
         """
 
         all_params = ['name', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -963,7 +963,7 @@ class DistributedStorageApi(object):
             files=local_var_files,
             response_type='DistributedDevice',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -973,11 +973,11 @@ class DistributedStorageApi(object):
         """Returns a list of DistributedDevices  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_distributed_devices(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_distributed_devices(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: Filter results by name. See LexicalQueryExpression for details.
         :param str capacity: Filter results by capacity.  See NumericQueryExpression for details.
         :param str thin_capable: Filter results by thin_capable.  See LexicalQueryExpression for details.
@@ -992,7 +992,7 @@ class DistributedStorageApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_distributed_devices_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_distributed_devices_with_http_info(**kwargs)  # noqa: E501
@@ -1002,11 +1002,11 @@ class DistributedStorageApi(object):
         """Returns a list of DistributedDevices  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_distributed_devices_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_distributed_devices_with_http_info(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: Filter results by name. See LexicalQueryExpression for details.
         :param str capacity: Filter results by capacity.  See NumericQueryExpression for details.
         :param str thin_capable: Filter results by thin_capable.  See LexicalQueryExpression for details.
@@ -1022,7 +1022,7 @@ class DistributedStorageApi(object):
         """
 
         all_params = ['name', 'capacity', 'thin_capable', 'health_state', 'operational_status', 'offset', 'limit', 'sort_by', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1090,7 +1090,7 @@ class DistributedStorageApi(object):
             files=local_var_files,
             response_type='list[DistributedDevice]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1100,18 +1100,18 @@ class DistributedStorageApi(object):
         """Returns a single distributed VirtualVolume object  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_distributed_virtual_volume(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_distributed_virtual_volume(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :return: VirtualVolume
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_distributed_virtual_volume_with_http_info(name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_distributed_virtual_volume_with_http_info(name, **kwargs)  # noqa: E501
@@ -1121,11 +1121,11 @@ class DistributedStorageApi(object):
         """Returns a single distributed VirtualVolume object  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_distributed_virtual_volume_with_http_info(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_distributed_virtual_volume_with_http_info(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :return: VirtualVolume
                  If the method is called asynchronously,
@@ -1133,7 +1133,7 @@ class DistributedStorageApi(object):
         """
 
         all_params = ['name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1179,7 +1179,7 @@ class DistributedStorageApi(object):
             files=local_var_files,
             response_type='VirtualVolume',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1189,11 +1189,11 @@ class DistributedStorageApi(object):
         """Returns a list of distributed VirtualVolumes  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_distributed_virtual_volumes(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_distributed_virtual_volumes(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
         :param int limit: <p>Maximum number of elements to include in paginated results.<br> <b>'offset' must also be specified.<b>
         :param str name: Filter results by name. See LexicalQueryExpression for details.
@@ -1210,7 +1210,7 @@ class DistributedStorageApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_distributed_virtual_volumes_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_distributed_virtual_volumes_with_http_info(**kwargs)  # noqa: E501
@@ -1220,11 +1220,11 @@ class DistributedStorageApi(object):
         """Returns a list of distributed VirtualVolumes  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_distributed_virtual_volumes_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_distributed_virtual_volumes_with_http_info(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
         :param int limit: <p>Maximum number of elements to include in paginated results.<br> <b>'offset' must also be specified.<b>
         :param str name: Filter results by name. See LexicalQueryExpression for details.
@@ -1242,7 +1242,7 @@ class DistributedStorageApi(object):
         """
 
         all_params = ['offset', 'limit', 'name', 'capacity', 'sort_by', 'fields', 'consistency_group', 'health_state', 'operational_status', 'service_status', 'thin_enabled']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1310,7 +1310,7 @@ class DistributedStorageApi(object):
             files=local_var_files,
             response_type='list[VirtualVolume]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1320,18 +1320,18 @@ class DistributedStorageApi(object):
         """Returns a single RuleSet object  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_rule_set(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_rule_set(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :return: RuleSet
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_rule_set_with_http_info(name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_rule_set_with_http_info(name, **kwargs)  # noqa: E501
@@ -1341,11 +1341,11 @@ class DistributedStorageApi(object):
         """Returns a single RuleSet object  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_rule_set_with_http_info(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_rule_set_with_http_info(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :return: RuleSet
                  If the method is called asynchronously,
@@ -1353,7 +1353,7 @@ class DistributedStorageApi(object):
         """
 
         all_params = ['name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1399,7 +1399,7 @@ class DistributedStorageApi(object):
             files=local_var_files,
             response_type='RuleSet',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1409,11 +1409,11 @@ class DistributedStorageApi(object):
         """Returns a list of RuleSets  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_rule_sets(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_rule_sets(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
         :param int limit: <p>Maximum number of elements to include in paginated results.<br> <b>'offset' must also be specified.<b>
         :param str name: Filter results by name. See LexicalQueryExpression for details.
@@ -1422,7 +1422,7 @@ class DistributedStorageApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_rule_sets_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_rule_sets_with_http_info(**kwargs)  # noqa: E501
@@ -1432,11 +1432,11 @@ class DistributedStorageApi(object):
         """Returns a list of RuleSets  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_rule_sets_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_rule_sets_with_http_info(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
         :param int limit: <p>Maximum number of elements to include in paginated results.<br> <b>'offset' must also be specified.<b>
         :param str name: Filter results by name. See LexicalQueryExpression for details.
@@ -1446,7 +1446,7 @@ class DistributedStorageApi(object):
         """
 
         all_params = ['offset', 'limit', 'name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1502,7 +1502,7 @@ class DistributedStorageApi(object):
             files=local_var_files,
             response_type='list[RuleSet]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1513,11 +1513,11 @@ class DistributedStorageApi(object):
 
         Patchable attributes are 'storage_at_clusters' (add/remove), 'virtual_volumes' (add/remove), 'visibility' (add/remove), 'name', 'auto_resume_at_loser' and 'detach_rule'   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_distributed_consistency_group(name, distributed_consistency_group_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_distributed_consistency_group(name, distributed_consistency_group_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :param list[JsonPatchOp] distributed_consistency_group_patch_payload: (required)
         :return: ConsistencyGroup
@@ -1525,7 +1525,7 @@ class DistributedStorageApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.patch_distributed_consistency_group_with_http_info(name, distributed_consistency_group_patch_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.patch_distributed_consistency_group_with_http_info(name, distributed_consistency_group_patch_payload, **kwargs)  # noqa: E501
@@ -1536,11 +1536,11 @@ class DistributedStorageApi(object):
 
         Patchable attributes are 'storage_at_clusters' (add/remove), 'virtual_volumes' (add/remove), 'visibility' (add/remove), 'name', 'auto_resume_at_loser' and 'detach_rule'   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_distributed_consistency_group_with_http_info(name, distributed_consistency_group_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_distributed_consistency_group_with_http_info(name, distributed_consistency_group_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :param list[JsonPatchOp] distributed_consistency_group_patch_payload: (required)
         :return: ConsistencyGroup
@@ -1549,7 +1549,7 @@ class DistributedStorageApi(object):
         """
 
         all_params = ['name', 'distributed_consistency_group_patch_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1601,7 +1601,7 @@ class DistributedStorageApi(object):
             files=local_var_files,
             response_type='ConsistencyGroup',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1612,11 +1612,11 @@ class DistributedStorageApi(object):
 
         Settable attributes: 'name', 'legs', 'transfer_size', 'rule_set_name'   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_distributed_device(name, distributed_device_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_distributed_device(name, distributed_device_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :param list[JsonPatchOp] distributed_device_patch_payload: (required)
         :return: DistributedDevice
@@ -1624,7 +1624,7 @@ class DistributedStorageApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.patch_distributed_device_with_http_info(name, distributed_device_patch_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.patch_distributed_device_with_http_info(name, distributed_device_patch_payload, **kwargs)  # noqa: E501
@@ -1635,11 +1635,11 @@ class DistributedStorageApi(object):
 
         Settable attributes: 'name', 'legs', 'transfer_size', 'rule_set_name'   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_distributed_device_with_http_info(name, distributed_device_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_distributed_device_with_http_info(name, distributed_device_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :param list[JsonPatchOp] distributed_device_patch_payload: (required)
         :return: DistributedDevice
@@ -1648,7 +1648,7 @@ class DistributedStorageApi(object):
         """
 
         all_params = ['name', 'distributed_device_patch_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1700,7 +1700,7 @@ class DistributedStorageApi(object):
             files=local_var_files,
             response_type='DistributedDevice',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1711,11 +1711,11 @@ class DistributedStorageApi(object):
 
         Settable attributes: 'name'   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_distributed_virtual_volume(name, distributed_virtual_volume_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_distributed_virtual_volume(name, distributed_virtual_volume_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :param list[JsonPatchOp] distributed_virtual_volume_patch_payload: (required)
         :return: VirtualVolume
@@ -1723,7 +1723,7 @@ class DistributedStorageApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.patch_distributed_virtual_volume_with_http_info(name, distributed_virtual_volume_patch_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.patch_distributed_virtual_volume_with_http_info(name, distributed_virtual_volume_patch_payload, **kwargs)  # noqa: E501
@@ -1734,11 +1734,11 @@ class DistributedStorageApi(object):
 
         Settable attributes: 'name'   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_distributed_virtual_volume_with_http_info(name, distributed_virtual_volume_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_distributed_virtual_volume_with_http_info(name, distributed_virtual_volume_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :param list[JsonPatchOp] distributed_virtual_volume_patch_payload: (required)
         :return: VirtualVolume
@@ -1747,7 +1747,7 @@ class DistributedStorageApi(object):
         """
 
         all_params = ['name', 'distributed_virtual_volume_patch_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1799,7 +1799,7 @@ class DistributedStorageApi(object):
             files=local_var_files,
             response_type='VirtualVolume',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1809,11 +1809,11 @@ class DistributedStorageApi(object):
         """Manually resume I/O to the virtual-volumes in a distributed consistency group.  In a cluster-partition scenario where the ruleset does not indicate an automatic winner, this endpoint will select the winning cluster where I/O should continue.  After a cluster-partition is resolved, in the case that auto-resume-at-loser is set to false, this endpoint will resume I/O on the losing cluster.   # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.resume(name, cg_resume_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.resume(name, cg_resume_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :param CgResumePayload cg_resume_payload: (required)
         :return: ConsistencyGroup
@@ -1821,7 +1821,7 @@ class DistributedStorageApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.resume_with_http_info(name, cg_resume_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.resume_with_http_info(name, cg_resume_payload, **kwargs)  # noqa: E501
@@ -1831,11 +1831,11 @@ class DistributedStorageApi(object):
         """Manually resume I/O to the virtual-volumes in a distributed consistency group.  In a cluster-partition scenario where the ruleset does not indicate an automatic winner, this endpoint will select the winning cluster where I/O should continue.  After a cluster-partition is resolved, in the case that auto-resume-at-loser is set to false, this endpoint will resume I/O on the losing cluster.   # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.resume_with_http_info(name, cg_resume_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.resume_with_http_info(name, cg_resume_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :param CgResumePayload cg_resume_payload: (required)
         :return: ConsistencyGroup
@@ -1844,7 +1844,7 @@ class DistributedStorageApi(object):
         """
 
         all_params = ['name', 'cg_resume_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1900,7 +1900,7 @@ class DistributedStorageApi(object):
             files=local_var_files,
             response_type='ConsistencyGroup',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1910,18 +1910,18 @@ class DistributedStorageApi(object):
         """Manually resume I/O to a distributed device that supports a distributed virtual-volume.  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.resume_link_up(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.resume_link_up(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :return: DistributedDevice
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.resume_link_up_with_http_info(name, **kwargs)  # noqa: E501
         else:
             (data) = self.resume_link_up_with_http_info(name, **kwargs)  # noqa: E501
@@ -1931,11 +1931,11 @@ class DistributedStorageApi(object):
         """Manually resume I/O to a distributed device that supports a distributed virtual-volume.  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.resume_link_up_with_http_info(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.resume_link_up_with_http_info(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :return: DistributedDevice
                  If the method is called asynchronously,
@@ -1943,7 +1943,7 @@ class DistributedStorageApi(object):
         """
 
         all_params = ['name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1993,7 +1993,7 @@ class DistributedStorageApi(object):
             files=local_var_files,
             response_type='DistributedDevice',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/engine_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/engine_api.py
@@ -37,11 +37,11 @@ class EngineApi(object):
         """Return a Engine matching the provided name  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_engine(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_engine(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
         :return: Engine
@@ -49,7 +49,7 @@ class EngineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_engine_with_http_info(name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_engine_with_http_info(name, **kwargs)  # noqa: E501
@@ -59,11 +59,11 @@ class EngineApi(object):
         """Return a Engine matching the provided name  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_engine_with_http_info(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_engine_with_http_info(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
         :return: Engine
@@ -72,7 +72,7 @@ class EngineApi(object):
         """
 
         all_params = ['name', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -120,7 +120,7 @@ class EngineApi(object):
             files=local_var_files,
             response_type='Engine',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -130,11 +130,11 @@ class EngineApi(object):
         """Returns a list of the available engines  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_engines(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_engines(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
         :param int limit: <p>Maximum number of elements to include in paginated results.<br> <b>'offset' must also be specified.<b>
         :param str sort_by: Specify the field priority order and direction for sorting.  See SortingOrderExpression for details. 
@@ -146,7 +146,7 @@ class EngineApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_engines_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_engines_with_http_info(**kwargs)  # noqa: E501
@@ -156,11 +156,11 @@ class EngineApi(object):
         """Returns a list of the available engines  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_engines_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_engines_with_http_info(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
         :param int limit: <p>Maximum number of elements to include in paginated results.<br> <b>'offset' must also be specified.<b>
         :param str sort_by: Specify the field priority order and direction for sorting.  See SortingOrderExpression for details. 
@@ -173,7 +173,7 @@ class EngineApi(object):
         """
 
         all_params = ['offset', 'limit', 'sort_by', 'fields', 'health_state', 'operational_status']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -231,7 +231,7 @@ class EngineApi(object):
             files=local_var_files,
             response_type='list[Engine]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/exports_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/exports_api.py
@@ -37,11 +37,11 @@ class ExportsApi(object):
         """Create a new StorageView  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_storage_view(cluster_name, storage_view_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.create_storage_view(cluster_name, storage_view_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param StorageViewPayload storage_view_payload: (required)
         :param str x_include_object: When passed as part of a POST request, controls whether the representation of the newly created object is included in the response. Defaults to 'true' which will include the object in the response. This header is useful because refreshing the newly created object is usually the slowest part of a POST operation. 
@@ -50,7 +50,7 @@ class ExportsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.create_storage_view_with_http_info(cluster_name, storage_view_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.create_storage_view_with_http_info(cluster_name, storage_view_payload, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ExportsApi(object):
         """Create a new StorageView  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_storage_view_with_http_info(cluster_name, storage_view_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.create_storage_view_with_http_info(cluster_name, storage_view_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param StorageViewPayload storage_view_payload: (required)
         :param str x_include_object: When passed as part of a POST request, controls whether the representation of the newly created object is included in the response. Defaults to 'true' which will include the object in the response. This header is useful because refreshing the newly created object is usually the slowest part of a POST operation. 
@@ -74,7 +74,7 @@ class ExportsApi(object):
         """
 
         all_params = ['cluster_name', 'storage_view_payload', 'x_include_object']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -128,7 +128,7 @@ class ExportsApi(object):
             files=local_var_files,
             response_type='StorageView',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -138,11 +138,11 @@ class ExportsApi(object):
         """Deletes a single StorageView  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_storage_view(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_storage_view(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: (required)
         :return: None
@@ -150,7 +150,7 @@ class ExportsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.delete_storage_view_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_storage_view_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class ExportsApi(object):
         """Deletes a single StorageView  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_storage_view_with_http_info(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_storage_view_with_http_info(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: (required)
         :return: None
@@ -173,7 +173,7 @@ class ExportsApi(object):
         """
 
         all_params = ['cluster_name', 'name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -225,7 +225,7 @@ class ExportsApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -235,11 +235,11 @@ class ExportsApi(object):
         """Returns a single InitiatorPort object  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_initiator_port(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_initiator_port(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
@@ -248,7 +248,7 @@ class ExportsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_initiator_port_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_initiator_port_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
@@ -258,11 +258,11 @@ class ExportsApi(object):
         """Returns a single InitiatorPort object  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_initiator_port_with_http_info(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_initiator_port_with_http_info(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
@@ -272,7 +272,7 @@ class ExportsApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -326,7 +326,7 @@ class ExportsApi(object):
             files=local_var_files,
             response_type='InitiatorPort',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -336,11 +336,11 @@ class ExportsApi(object):
         """Returns a list of InitiatorPort objects  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_initiator_ports(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_initiator_ports(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: Filter results by name. See LexicalQueryExpression for details.
         :param str type: Filter results by type. See LexicalQueryExpression for details.
@@ -353,7 +353,7 @@ class ExportsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_initiator_ports_with_http_info(cluster_name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_initiator_ports_with_http_info(cluster_name, **kwargs)  # noqa: E501
@@ -363,11 +363,11 @@ class ExportsApi(object):
         """Returns a list of InitiatorPort objects  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_initiator_ports_with_http_info(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_initiator_ports_with_http_info(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: Filter results by name. See LexicalQueryExpression for details.
         :param str type: Filter results by type. See LexicalQueryExpression for details.
@@ -381,7 +381,7 @@ class ExportsApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'type', 'offset', 'limit', 'sort_by', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -445,7 +445,7 @@ class ExportsApi(object):
             files=local_var_files,
             response_type='list[InitiatorPort]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -455,11 +455,11 @@ class ExportsApi(object):
         """Returns a single Port object  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_port(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_port(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: Port
@@ -467,7 +467,7 @@ class ExportsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_port_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_port_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
@@ -477,11 +477,11 @@ class ExportsApi(object):
         """Returns a single Port object  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_port_with_http_info(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_port_with_http_info(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: Port
@@ -490,7 +490,7 @@ class ExportsApi(object):
         """
 
         all_params = ['cluster_name', 'name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -542,7 +542,7 @@ class ExportsApi(object):
             files=local_var_files,
             response_type='Port',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -552,11 +552,11 @@ class ExportsApi(object):
         """Returns a list of Port objects  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_ports(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_ports(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
         :param int limit: <p>Maximum number of elements to include in paginated results.<br> <b>'offset' must also be specified.<b>
@@ -568,7 +568,7 @@ class ExportsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_ports_with_http_info(cluster_name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_ports_with_http_info(cluster_name, **kwargs)  # noqa: E501
@@ -578,11 +578,11 @@ class ExportsApi(object):
         """Returns a list of Port objects  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_ports_with_http_info(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_ports_with_http_info(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
         :param int limit: <p>Maximum number of elements to include in paginated results.<br> <b>'offset' must also be specified.<b>
@@ -595,7 +595,7 @@ class ExportsApi(object):
         """
 
         all_params = ['cluster_name', 'offset', 'limit', 'name', 'sort_by', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -657,7 +657,7 @@ class ExportsApi(object):
             files=local_var_files,
             response_type='list[Port]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -667,11 +667,11 @@ class ExportsApi(object):
         """Returns a single StorageView  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_storage_view(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_storage_view(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: StorageView
@@ -679,7 +679,7 @@ class ExportsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_storage_view_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_storage_view_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
@@ -689,11 +689,11 @@ class ExportsApi(object):
         """Returns a single StorageView  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_storage_view_with_http_info(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_storage_view_with_http_info(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: StorageView
@@ -702,7 +702,7 @@ class ExportsApi(object):
         """
 
         all_params = ['cluster_name', 'name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -754,7 +754,7 @@ class ExportsApi(object):
             files=local_var_files,
             response_type='StorageView',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -764,11 +764,11 @@ class ExportsApi(object):
         """Returns a list of StorageView objects  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_storage_views(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_storage_views(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
         :param int limit: <p>Maximum number of elements to include in paginated results.<br> <b>'offset' must also be specified.<b>
@@ -781,7 +781,7 @@ class ExportsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_storage_views_with_http_info(cluster_name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_storage_views_with_http_info(cluster_name, **kwargs)  # noqa: E501
@@ -791,11 +791,11 @@ class ExportsApi(object):
         """Returns a list of StorageView objects  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_storage_views_with_http_info(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_storage_views_with_http_info(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
         :param int limit: <p>Maximum number of elements to include in paginated results.<br> <b>'offset' must also be specified.<b>
@@ -809,7 +809,7 @@ class ExportsApi(object):
         """
 
         all_params = ['cluster_name', 'offset', 'limit', 'name', 'operational_status', 'sort_by', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -873,7 +873,7 @@ class ExportsApi(object):
             files=local_var_files,
             response_type='list[StorageView]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -884,11 +884,11 @@ class ExportsApi(object):
 
         Settable attributes: 'name','iops_limit','bandwidth_limit'   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_initiator_port(cluster_name, name, initiator_port_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_initiator_port(cluster_name, name, initiator_port_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param list[JsonPatchOp] initiator_port_patch_payload: (required)
@@ -897,7 +897,7 @@ class ExportsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.patch_initiator_port_with_http_info(cluster_name, name, initiator_port_patch_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.patch_initiator_port_with_http_info(cluster_name, name, initiator_port_patch_payload, **kwargs)  # noqa: E501
@@ -908,11 +908,11 @@ class ExportsApi(object):
 
         Settable attributes: 'name','iops_limit','bandwidth_limit'   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_initiator_port_with_http_info(cluster_name, name, initiator_port_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_initiator_port_with_http_info(cluster_name, name, initiator_port_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param list[JsonPatchOp] initiator_port_patch_payload: (required)
@@ -922,7 +922,7 @@ class ExportsApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'initiator_port_patch_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -980,7 +980,7 @@ class ExportsApi(object):
             files=local_var_files,
             response_type='InitiatorPort',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -991,11 +991,11 @@ class ExportsApi(object):
 
         Settable attributes are 'name' and 'enabled'   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_port(cluster_name, name, port_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_port(cluster_name, name, port_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param list[JsonPatchOp] port_patch_payload: (required)
@@ -1004,7 +1004,7 @@ class ExportsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.patch_port_with_http_info(cluster_name, name, port_patch_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.patch_port_with_http_info(cluster_name, name, port_patch_payload, **kwargs)  # noqa: E501
@@ -1015,11 +1015,11 @@ class ExportsApi(object):
 
         Settable attributes are 'name' and 'enabled'   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_port_with_http_info(cluster_name, name, port_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_port_with_http_info(cluster_name, name, port_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param list[JsonPatchOp] port_patch_payload: (required)
@@ -1029,7 +1029,7 @@ class ExportsApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'port_patch_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1087,7 +1087,7 @@ class ExportsApi(object):
             files=local_var_files,
             response_type='Port',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1098,11 +1098,11 @@ class ExportsApi(object):
 
         Settable attributes: 'name', 'initiators'(add/remove), 'virtual_volumes'(add/remove), 'ports'(add/remove)   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_storage_view(cluster_name, name, storage_view_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_storage_view(cluster_name, name, storage_view_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param list[JsonPatchOp] storage_view_patch_payload: (required)
@@ -1112,7 +1112,7 @@ class ExportsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.patch_storage_view_with_http_info(cluster_name, name, storage_view_patch_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.patch_storage_view_with_http_info(cluster_name, name, storage_view_patch_payload, **kwargs)  # noqa: E501
@@ -1123,11 +1123,11 @@ class ExportsApi(object):
 
         Settable attributes: 'name', 'initiators'(add/remove), 'virtual_volumes'(add/remove), 'ports'(add/remove)   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_storage_view_with_http_info(cluster_name, name, storage_view_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_storage_view_with_http_info(cluster_name, name, storage_view_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param list[JsonPatchOp] storage_view_patch_payload: (required)
@@ -1138,7 +1138,7 @@ class ExportsApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'storage_view_patch_payload', 'allow_multi_fail']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1198,7 +1198,7 @@ class ExportsApi(object):
             files=local_var_files,
             response_type='StorageView',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1208,11 +1208,11 @@ class ExportsApi(object):
         """Rediscover initiator ports  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.rediscover_initiator_ports(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.rediscover_initiator_ports(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param RediscoverPayload rediscover_payload:
         :return: list[InitiatorPort]
@@ -1220,7 +1220,7 @@ class ExportsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.rediscover_initiator_ports_with_http_info(cluster_name, **kwargs)  # noqa: E501
         else:
             (data) = self.rediscover_initiator_ports_with_http_info(cluster_name, **kwargs)  # noqa: E501
@@ -1230,11 +1230,11 @@ class ExportsApi(object):
         """Rediscover initiator ports  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.rediscover_initiator_ports_with_http_info(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.rediscover_initiator_ports_with_http_info(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param RediscoverPayload rediscover_payload:
         :return: list[InitiatorPort]
@@ -1243,7 +1243,7 @@ class ExportsApi(object):
         """
 
         all_params = ['cluster_name', 'rediscover_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1291,7 +1291,7 @@ class ExportsApi(object):
             files=local_var_files,
             response_type='list[InitiatorPort]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1301,11 +1301,11 @@ class ExportsApi(object):
         """Registers an InitiatorPort  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.register_initiator_port(cluster_name, register_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.register_initiator_port(cluster_name, register_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param RegisterPayload register_payload: (required)
         :return: InitiatorPort
@@ -1313,7 +1313,7 @@ class ExportsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.register_initiator_port_with_http_info(cluster_name, register_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.register_initiator_port_with_http_info(cluster_name, register_payload, **kwargs)  # noqa: E501
@@ -1323,11 +1323,11 @@ class ExportsApi(object):
         """Registers an InitiatorPort  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.register_initiator_port_with_http_info(cluster_name, register_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.register_initiator_port_with_http_info(cluster_name, register_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param RegisterPayload register_payload: (required)
         :return: InitiatorPort
@@ -1336,7 +1336,7 @@ class ExportsApi(object):
         """
 
         all_params = ['cluster_name', 'register_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1388,7 +1388,7 @@ class ExportsApi(object):
             files=local_var_files,
             response_type='InitiatorPort',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -1398,11 +1398,11 @@ class ExportsApi(object):
         """Unregister an InitiatorPort  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.unregister_initiator_port(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.unregister_initiator_port(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: None
@@ -1410,7 +1410,7 @@ class ExportsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.unregister_initiator_port_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.unregister_initiator_port_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
@@ -1420,11 +1420,11 @@ class ExportsApi(object):
         """Unregister an InitiatorPort  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.unregister_initiator_port_with_http_info(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.unregister_initiator_port_with_http_info(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: None
@@ -1433,7 +1433,7 @@ class ExportsApi(object):
         """
 
         all_params = ['cluster_name', 'name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -1485,7 +1485,7 @@ class ExportsApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/extent_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/extent_api.py
@@ -37,11 +37,11 @@ class ExtentApi(object):
         """Create a new Extent  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_extent(cluster_name, extent_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.create_extent(cluster_name, extent_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param ExtentPayload extent_payload: (required)
         :param str x_include_object: When passed as part of a POST request, controls whether the representation of the newly created object is included in the response. Defaults to 'true' which will include the object in the response. This header is useful because refreshing the newly created object is usually the slowest part of a POST operation. 
@@ -50,7 +50,7 @@ class ExtentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.create_extent_with_http_info(cluster_name, extent_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.create_extent_with_http_info(cluster_name, extent_payload, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class ExtentApi(object):
         """Create a new Extent  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_extent_with_http_info(cluster_name, extent_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.create_extent_with_http_info(cluster_name, extent_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param ExtentPayload extent_payload: (required)
         :param str x_include_object: When passed as part of a POST request, controls whether the representation of the newly created object is included in the response. Defaults to 'true' which will include the object in the response. This header is useful because refreshing the newly created object is usually the slowest part of a POST operation. 
@@ -74,7 +74,7 @@ class ExtentApi(object):
         """
 
         all_params = ['cluster_name', 'extent_payload', 'x_include_object']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -128,7 +128,7 @@ class ExtentApi(object):
             files=local_var_files,
             response_type='Extent',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -138,11 +138,11 @@ class ExtentApi(object):
         """Delets a single Extent object  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_extent(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_extent(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: None
@@ -150,7 +150,7 @@ class ExtentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.delete_extent_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_extent_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class ExtentApi(object):
         """Delets a single Extent object  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_extent_with_http_info(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_extent_with_http_info(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: None
@@ -173,7 +173,7 @@ class ExtentApi(object):
         """
 
         all_params = ['cluster_name', 'name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -225,7 +225,7 @@ class ExtentApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -235,11 +235,11 @@ class ExtentApi(object):
         """Returns a single Extent object  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_extent(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_extent(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
@@ -248,7 +248,7 @@ class ExtentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_extent_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_extent_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
@@ -258,11 +258,11 @@ class ExtentApi(object):
         """Returns a single Extent object  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_extent_with_http_info(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_extent_with_http_info(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
@@ -272,7 +272,7 @@ class ExtentApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -326,7 +326,7 @@ class ExtentApi(object):
             files=local_var_files,
             response_type='Extent',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -336,11 +336,11 @@ class ExtentApi(object):
         """Returns a list of Extent objects  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_extents(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_extents(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: Filter results by name. See LexicalQueryExpression for details.
         :param str use: Filter results by use. See LexicalQueryExpression for details.
@@ -354,7 +354,7 @@ class ExtentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_extents_with_http_info(cluster_name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_extents_with_http_info(cluster_name, **kwargs)  # noqa: E501
@@ -364,11 +364,11 @@ class ExtentApi(object):
         """Returns a list of Extent objects  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_extents_with_http_info(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_extents_with_http_info(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: Filter results by name. See LexicalQueryExpression for details.
         :param str use: Filter results by use. See LexicalQueryExpression for details.
@@ -383,7 +383,7 @@ class ExtentApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'use', 'capacity', 'offset', 'limit', 'sort_by', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -449,7 +449,7 @@ class ExtentApi(object):
             files=local_var_files,
             response_type='list[Extent]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -460,11 +460,11 @@ class ExtentApi(object):
 
         Settable attributes: 'name'   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_extent(cluster_name, name, extent_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_extent(cluster_name, name, extent_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param list[JsonPatchOp] extent_patch_payload: (required)
@@ -473,7 +473,7 @@ class ExtentApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.patch_extent_with_http_info(cluster_name, name, extent_patch_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.patch_extent_with_http_info(cluster_name, name, extent_patch_payload, **kwargs)  # noqa: E501
@@ -484,11 +484,11 @@ class ExtentApi(object):
 
         Settable attributes: 'name'   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_extent_with_http_info(cluster_name, name, extent_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_extent_with_http_info(cluster_name, name, extent_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param list[JsonPatchOp] extent_patch_payload: (required)
@@ -498,7 +498,7 @@ class ExtentApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'extent_patch_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -556,7 +556,7 @@ class ExtentApi(object):
             files=local_var_files,
             response_type='Extent',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/hardware_ports_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/hardware_ports_api.py
@@ -37,11 +37,11 @@ class HardwarePortsApi(object):
         """Returns a list of hardware ports  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_hardware_ports(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_hardware_ports(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
         :param int limit: <p>Maximum number of elements to include in paginated results.<br> <b>'offset' must also be specified.<b>
         :param str sort_by: Specify the field priority order and direction for sorting.  See SortingOrderExpression for details. 
@@ -55,7 +55,7 @@ class HardwarePortsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_hardware_ports_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_hardware_ports_with_http_info(**kwargs)  # noqa: E501
@@ -65,11 +65,11 @@ class HardwarePortsApi(object):
         """Returns a list of hardware ports  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_hardware_ports_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_hardware_ports_with_http_info(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
         :param int limit: <p>Maximum number of elements to include in paginated results.<br> <b>'offset' must also be specified.<b>
         :param str sort_by: Specify the field priority order and direction for sorting.  See SortingOrderExpression for details. 
@@ -84,7 +84,7 @@ class HardwarePortsApi(object):
         """
 
         all_params = ['offset', 'limit', 'sort_by', 'fields', 'name', 'director', 'status', 'role']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -146,7 +146,7 @@ class HardwarePortsApi(object):
             files=local_var_files,
             response_type='HardwarePorts',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/health_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/health_api.py
@@ -37,18 +37,18 @@ class HealthApi(object):
         """Return local-COM health information  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_local_com_health(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_local_com_health(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :return: LocalComHealth
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_local_com_health_with_http_info(cluster_name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_local_com_health_with_http_info(cluster_name, **kwargs)  # noqa: E501
@@ -58,11 +58,11 @@ class HealthApi(object):
         """Return local-COM health information  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_local_com_health_with_http_info(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_local_com_health_with_http_info(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :return: LocalComHealth
                  If the method is called asynchronously,
@@ -70,7 +70,7 @@ class HealthApi(object):
         """
 
         all_params = ['cluster_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -116,7 +116,7 @@ class HealthApi(object):
             files=local_var_files,
             response_type='LocalComHealth',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -126,17 +126,17 @@ class HealthApi(object):
         """Return WAN-COM health information  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_wan_com_health(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_wan_com_health(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :return: WanComHealth
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_wan_com_health_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_wan_com_health_with_http_info(**kwargs)  # noqa: E501
@@ -146,18 +146,18 @@ class HealthApi(object):
         """Return WAN-COM health information  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_wan_com_health_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_wan_com_health_with_http_info(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :return: WanComHealth
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
         all_params = []  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -197,7 +197,7 @@ class HealthApi(object):
             files=local_var_files,
             response_type='WanComHealth',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/jobs_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/jobs_api.py
@@ -37,18 +37,18 @@ class JobsApi(object):
         """Cancel a vias provisioning job  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.cancel_vias_job(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.cancel_vias_job(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :return: ViasJob
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.cancel_vias_job_with_http_info(name, **kwargs)  # noqa: E501
         else:
             (data) = self.cancel_vias_job_with_http_info(name, **kwargs)  # noqa: E501
@@ -58,11 +58,11 @@ class JobsApi(object):
         """Cancel a vias provisioning job  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.cancel_vias_job_with_http_info(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.cancel_vias_job_with_http_info(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :return: ViasJob
                  If the method is called asynchronously,
@@ -70,7 +70,7 @@ class JobsApi(object):
         """
 
         all_params = ['name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -116,7 +116,7 @@ class JobsApi(object):
             files=local_var_files,
             response_type='ViasJob',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -126,18 +126,18 @@ class JobsApi(object):
         """Create a VIAS provisioning job  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_vias_job(vias_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.create_vias_job(vias_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param ViasPayload vias_payload: (required)
         :return: ViasJob
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.create_vias_job_with_http_info(vias_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.create_vias_job_with_http_info(vias_payload, **kwargs)  # noqa: E501
@@ -147,11 +147,11 @@ class JobsApi(object):
         """Create a VIAS provisioning job  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_vias_job_with_http_info(vias_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.create_vias_job_with_http_info(vias_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param ViasPayload vias_payload: (required)
         :return: ViasJob
                  If the method is called asynchronously,
@@ -159,7 +159,7 @@ class JobsApi(object):
         """
 
         all_params = ['vias_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -205,7 +205,7 @@ class JobsApi(object):
             files=local_var_files,
             response_type='ViasJob',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -215,18 +215,18 @@ class JobsApi(object):
         """Delete a VIAS provisioning jobs  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_vias_job(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_vias_job(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.delete_vias_job_with_http_info(name, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_vias_job_with_http_info(name, **kwargs)  # noqa: E501
@@ -236,11 +236,11 @@ class JobsApi(object):
         """Delete a VIAS provisioning jobs  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_vias_job_with_http_info(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_vias_job_with_http_info(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :return: None
                  If the method is called asynchronously,
@@ -248,7 +248,7 @@ class JobsApi(object):
         """
 
         all_params = ['name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -294,7 +294,7 @@ class JobsApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -304,11 +304,11 @@ class JobsApi(object):
         """Get the status of a VIAS provisioning job  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_vias_job(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_vias_job(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
         :return: ViasJob
@@ -316,7 +316,7 @@ class JobsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_vias_job_with_http_info(name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_vias_job_with_http_info(name, **kwargs)  # noqa: E501
@@ -326,11 +326,11 @@ class JobsApi(object):
         """Get the status of a VIAS provisioning job  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_vias_job_with_http_info(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_vias_job_with_http_info(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
         :return: ViasJob
@@ -339,7 +339,7 @@ class JobsApi(object):
         """
 
         all_params = ['name', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -387,7 +387,7 @@ class JobsApi(object):
             files=local_var_files,
             response_type='ViasJob',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -397,11 +397,11 @@ class JobsApi(object):
         """Get all the current VIAS provisioning jobs  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_vias_jobs(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_vias_jobs(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: Filter results by name. See LexicalQueryExpression for details.
         :param str status: Filter results by status. See LexicalQueryExpression for details.
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
@@ -413,7 +413,7 @@ class JobsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_vias_jobs_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_vias_jobs_with_http_info(**kwargs)  # noqa: E501
@@ -423,11 +423,11 @@ class JobsApi(object):
         """Get all the current VIAS provisioning jobs  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_vias_jobs_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_vias_jobs_with_http_info(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: Filter results by name. See LexicalQueryExpression for details.
         :param str status: Filter results by status. See LexicalQueryExpression for details.
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
@@ -440,7 +440,7 @@ class JobsApi(object):
         """
 
         all_params = ['name', 'status', 'offset', 'limit', 'sort_by', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -498,7 +498,7 @@ class JobsApi(object):
             files=local_var_files,
             response_type='list[ViasJob]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -508,18 +508,18 @@ class JobsApi(object):
         """Resubmit a vias provisioning job  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.resubmit_vias_job(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.resubmit_vias_job(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :return: ViasJob
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.resubmit_vias_job_with_http_info(name, **kwargs)  # noqa: E501
         else:
             (data) = self.resubmit_vias_job_with_http_info(name, **kwargs)  # noqa: E501
@@ -529,11 +529,11 @@ class JobsApi(object):
         """Resubmit a vias provisioning job  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.resubmit_vias_job_with_http_info(name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.resubmit_vias_job_with_http_info(name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str name: The name of a specific instance of the resource (required)
         :return: ViasJob
                  If the method is called asynchronously,
@@ -541,7 +541,7 @@ class JobsApi(object):
         """
 
         all_params = ['name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -587,7 +587,7 @@ class JobsApi(object):
             files=local_var_files,
             response_type='ViasJob',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/licenses_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/licenses_api.py
@@ -37,18 +37,18 @@ class LicensesApi(object):
         """Deletes the licenses  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_licenses(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_licenses(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.delete_licenses_with_http_info(cluster_name, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_licenses_with_http_info(cluster_name, **kwargs)  # noqa: E501
@@ -58,11 +58,11 @@ class LicensesApi(object):
         """Deletes the licenses  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_licenses_with_http_info(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_licenses_with_http_info(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :return: None
                  If the method is called asynchronously,
@@ -70,7 +70,7 @@ class LicensesApi(object):
         """
 
         all_params = ['cluster_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -116,7 +116,7 @@ class LicensesApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -126,11 +126,11 @@ class LicensesApi(object):
         """Returns a list of installed licenses on the setup  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_license_info(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_license_info(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
         :param int limit: <p>Maximum number of elements to include in paginated results.<br> <b>'offset' must also be specified.<b>
@@ -141,7 +141,7 @@ class LicensesApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_license_info_with_http_info(cluster_name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_license_info_with_http_info(cluster_name, **kwargs)  # noqa: E501
@@ -151,11 +151,11 @@ class LicensesApi(object):
         """Returns a list of installed licenses on the setup  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_license_info_with_http_info(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_license_info_with_http_info(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
         :param int limit: <p>Maximum number of elements to include in paginated results.<br> <b>'offset' must also be specified.<b>
@@ -167,7 +167,7 @@ class LicensesApi(object):
         """
 
         all_params = ['cluster_name', 'offset', 'limit', 'sort_by', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -227,7 +227,7 @@ class LicensesApi(object):
             files=local_var_files,
             response_type='LicenseArray',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -237,11 +237,11 @@ class LicensesApi(object):
         """Install a new license file  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.install_license(cluster_name, license_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.install_license(cluster_name, license_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param LicensePayload license_payload: (required)
         :param bool validate:
@@ -250,7 +250,7 @@ class LicensesApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.install_license_with_http_info(cluster_name, license_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.install_license_with_http_info(cluster_name, license_payload, **kwargs)  # noqa: E501
@@ -260,11 +260,11 @@ class LicensesApi(object):
         """Install a new license file  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.install_license_with_http_info(cluster_name, license_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.install_license_with_http_info(cluster_name, license_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param LicensePayload license_payload: (required)
         :param bool validate:
@@ -274,7 +274,7 @@ class LicensesApi(object):
         """
 
         all_params = ['cluster_name', 'license_payload', 'validate']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -332,7 +332,7 @@ class LicensesApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -342,11 +342,11 @@ class LicensesApi(object):
         """Validate a license file  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.validate_license(cluster_name, validate_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.validate_license(cluster_name, validate_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param ValidatePayload validate_payload: (required)
         :return: None
@@ -354,7 +354,7 @@ class LicensesApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.validate_license_with_http_info(cluster_name, validate_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.validate_license_with_http_info(cluster_name, validate_payload, **kwargs)  # noqa: E501
@@ -364,11 +364,11 @@ class LicensesApi(object):
         """Validate a license file  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.validate_license_with_http_info(cluster_name, validate_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.validate_license_with_http_info(cluster_name, validate_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param ValidatePayload validate_payload: (required)
         :return: None
@@ -377,7 +377,7 @@ class LicensesApi(object):
         """
 
         all_params = ['cluster_name', 'validate_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -429,7 +429,7 @@ class LicensesApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/logger_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/logger_api.py
@@ -37,18 +37,18 @@ class LoggerApi(object):
         """Log information on the server. This endpoint is intended for internal system use only.   # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.log(request, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.log(request, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param object request: (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.log_with_http_info(request, **kwargs)  # noqa: E501
         else:
             (data) = self.log_with_http_info(request, **kwargs)  # noqa: E501
@@ -58,11 +58,11 @@ class LoggerApi(object):
         """Log information on the server. This endpoint is intended for internal system use only.   # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.log_with_http_info(request, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.log_with_http_info(request, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param object request: (required)
         :return: None
                  If the method is called asynchronously,
@@ -70,7 +70,7 @@ class LoggerApi(object):
         """
 
         all_params = ['request']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -116,7 +116,7 @@ class LoggerApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/logging_volume_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/logging_volume_api.py
@@ -37,11 +37,11 @@ class LoggingVolumeApi(object):
         """Creates a new Logging Volume  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_logging_volume(cluster_name, logging_volume_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.create_logging_volume(cluster_name, logging_volume_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param LoggingVolumePayload logging_volume_payload: (required)
         :param str x_include_object: When passed as part of a POST request, controls whether the representation of the newly created object is included in the response. Defaults to 'true' which will include the object in the response. This header is useful because refreshing the newly created object is usually the slowest part of a POST operation. 
@@ -50,7 +50,7 @@ class LoggingVolumeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.create_logging_volume_with_http_info(cluster_name, logging_volume_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.create_logging_volume_with_http_info(cluster_name, logging_volume_payload, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class LoggingVolumeApi(object):
         """Creates a new Logging Volume  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_logging_volume_with_http_info(cluster_name, logging_volume_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.create_logging_volume_with_http_info(cluster_name, logging_volume_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param LoggingVolumePayload logging_volume_payload: (required)
         :param str x_include_object: When passed as part of a POST request, controls whether the representation of the newly created object is included in the response. Defaults to 'true' which will include the object in the response. This header is useful because refreshing the newly created object is usually the slowest part of a POST operation. 
@@ -74,7 +74,7 @@ class LoggingVolumeApi(object):
         """
 
         all_params = ['cluster_name', 'logging_volume_payload', 'x_include_object']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -128,7 +128,7 @@ class LoggingVolumeApi(object):
             files=local_var_files,
             response_type='LoggingVolume',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -138,11 +138,11 @@ class LoggingVolumeApi(object):
         """Deletes a single LoggingVolume  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_logging_volume(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_logging_volume(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: None
@@ -150,7 +150,7 @@ class LoggingVolumeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.delete_logging_volume_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_logging_volume_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class LoggingVolumeApi(object):
         """Deletes a single LoggingVolume  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_logging_volume_with_http_info(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_logging_volume_with_http_info(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: None
@@ -173,7 +173,7 @@ class LoggingVolumeApi(object):
         """
 
         all_params = ['cluster_name', 'name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -225,7 +225,7 @@ class LoggingVolumeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -235,11 +235,11 @@ class LoggingVolumeApi(object):
         """Returns a single LoggingVolume by name  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_logging_volume(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_logging_volume(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
@@ -248,7 +248,7 @@ class LoggingVolumeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_logging_volume_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_logging_volume_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
@@ -258,11 +258,11 @@ class LoggingVolumeApi(object):
         """Returns a single LoggingVolume by name  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_logging_volume_with_http_info(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_logging_volume_with_http_info(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
@@ -272,7 +272,7 @@ class LoggingVolumeApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -326,7 +326,7 @@ class LoggingVolumeApi(object):
             files=local_var_files,
             response_type='LoggingVolume',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -336,11 +336,11 @@ class LoggingVolumeApi(object):
         """Returns a list of LoggingVolume objects. Supports paging  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_logging_volumes(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_logging_volumes(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: Filter results by name. See LexicalQueryExpression for details.
         :param str health_state: Filter results by health_state. See LexicalQueryExpression for details.
@@ -354,7 +354,7 @@ class LoggingVolumeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_logging_volumes_with_http_info(cluster_name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_logging_volumes_with_http_info(cluster_name, **kwargs)  # noqa: E501
@@ -364,11 +364,11 @@ class LoggingVolumeApi(object):
         """Returns a list of LoggingVolume objects. Supports paging  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_logging_volumes_with_http_info(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_logging_volumes_with_http_info(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: Filter results by name. See LexicalQueryExpression for details.
         :param str health_state: Filter results by health_state. See LexicalQueryExpression for details.
@@ -383,7 +383,7 @@ class LoggingVolumeApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'health_state', 'operational_status', 'offset', 'limit', 'sort_by', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -449,7 +449,7 @@ class LoggingVolumeApi(object):
             files=local_var_files,
             response_type='list[LoggingVolume]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/logical_units_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/logical_units_api.py
@@ -37,11 +37,11 @@ class LogicalUnitsApi(object):
         """Forgets logicalUnits in an array  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.forget_logical_units(cluster_name, storagearray_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.forget_logical_units(cluster_name, storagearray_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str storagearray_name: The name of the storage array (required)
         :return: None
@@ -49,7 +49,7 @@ class LogicalUnitsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.forget_logical_units_with_http_info(cluster_name, storagearray_name, **kwargs)  # noqa: E501
         else:
             (data) = self.forget_logical_units_with_http_info(cluster_name, storagearray_name, **kwargs)  # noqa: E501
@@ -59,11 +59,11 @@ class LogicalUnitsApi(object):
         """Forgets logicalUnits in an array  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.forget_logical_units_with_http_info(cluster_name, storagearray_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.forget_logical_units_with_http_info(cluster_name, storagearray_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str storagearray_name: The name of the storage array (required)
         :return: None
@@ -72,7 +72,7 @@ class LogicalUnitsApi(object):
         """
 
         all_params = ['cluster_name', 'storagearray_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -124,7 +124,7 @@ class LogicalUnitsApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -134,11 +134,11 @@ class LogicalUnitsApi(object):
         """Returns a single LogicalUnit by name  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_logical_unit(cluster_name, storagearray_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_logical_unit(cluster_name, storagearray_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str storagearray_name: The name of the storage array (required)
         :param str name: The name of a specific instance of the resource (required)
@@ -148,7 +148,7 @@ class LogicalUnitsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_logical_unit_with_http_info(cluster_name, storagearray_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_logical_unit_with_http_info(cluster_name, storagearray_name, name, **kwargs)  # noqa: E501
@@ -158,11 +158,11 @@ class LogicalUnitsApi(object):
         """Returns a single LogicalUnit by name  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_logical_unit_with_http_info(cluster_name, storagearray_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_logical_unit_with_http_info(cluster_name, storagearray_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str storagearray_name: The name of the storage array (required)
         :param str name: The name of a specific instance of the resource (required)
@@ -173,7 +173,7 @@ class LogicalUnitsApi(object):
         """
 
         all_params = ['cluster_name', 'storagearray_name', 'name', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +233,7 @@ class LogicalUnitsApi(object):
             files=local_var_files,
             response_type='LogicalUnit',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -243,11 +243,11 @@ class LogicalUnitsApi(object):
         """Returns a list of LogicalUnits  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_logical_units(cluster_name, storagearray_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_logical_units(cluster_name, storagearray_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str storagearray_name: The name of the storage array (required)
         :param str name: Filter results by name. See LexicalQueryExpression for details.
@@ -261,7 +261,7 @@ class LogicalUnitsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_logical_units_with_http_info(cluster_name, storagearray_name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_logical_units_with_http_info(cluster_name, storagearray_name, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class LogicalUnitsApi(object):
         """Returns a list of LogicalUnits  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_logical_units_with_http_info(cluster_name, storagearray_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_logical_units_with_http_info(cluster_name, storagearray_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str storagearray_name: The name of the storage array (required)
         :param str name: Filter results by name. See LexicalQueryExpression for details.
@@ -290,7 +290,7 @@ class LogicalUnitsApi(object):
         """
 
         all_params = ['cluster_name', 'storagearray_name', 'name', 'storage_volume', 'offset', 'limit', 'sort_by', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -360,7 +360,7 @@ class LogicalUnitsApi(object):
             files=local_var_files,
             response_type='list[LogicalUnit]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/maps_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/maps_api.py
@@ -37,18 +37,18 @@ class MapsApi(object):
         """Get the parents and children for the passed element  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_map(uri, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_map(uri, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str uri: (required)
         :return: StorageMap
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_map_with_http_info(uri, **kwargs)  # noqa: E501
         else:
             (data) = self.get_map_with_http_info(uri, **kwargs)  # noqa: E501
@@ -58,11 +58,11 @@ class MapsApi(object):
         """Get the parents and children for the passed element  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_map_with_http_info(uri, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_map_with_http_info(uri, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str uri: (required)
         :return: StorageMap
                  If the method is called asynchronously,
@@ -70,7 +70,7 @@ class MapsApi(object):
         """
 
         all_params = ['uri']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -116,7 +116,7 @@ class MapsApi(object):
             files=local_var_files,
             response_type='StorageMap',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/meta_volume_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/meta_volume_api.py
@@ -37,11 +37,11 @@ class MetaVolumeApi(object):
         """Create a new MetaVolume  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_meta_volume(cluster_name, meta_volume_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.create_meta_volume(cluster_name, meta_volume_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param MetaVolumePayload meta_volume_payload: (required)
         :param str x_include_object: When passed as part of a POST request, controls whether the representation of the newly created object is included in the response. Defaults to 'true' which will include the object in the response. This header is useful because refreshing the newly created object is usually the slowest part of a POST operation. 
@@ -50,7 +50,7 @@ class MetaVolumeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.create_meta_volume_with_http_info(cluster_name, meta_volume_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.create_meta_volume_with_http_info(cluster_name, meta_volume_payload, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class MetaVolumeApi(object):
         """Create a new MetaVolume  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_meta_volume_with_http_info(cluster_name, meta_volume_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.create_meta_volume_with_http_info(cluster_name, meta_volume_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param MetaVolumePayload meta_volume_payload: (required)
         :param str x_include_object: When passed as part of a POST request, controls whether the representation of the newly created object is included in the response. Defaults to 'true' which will include the object in the response. This header is useful because refreshing the newly created object is usually the slowest part of a POST operation. 
@@ -74,7 +74,7 @@ class MetaVolumeApi(object):
         """
 
         all_params = ['cluster_name', 'meta_volume_payload', 'x_include_object']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -128,7 +128,7 @@ class MetaVolumeApi(object):
             files=local_var_files,
             response_type='MetaVolume',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -138,11 +138,11 @@ class MetaVolumeApi(object):
         """Deletes a single MetaVolume  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_meta_volume(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_meta_volume(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: None
@@ -150,7 +150,7 @@ class MetaVolumeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.delete_meta_volume_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_meta_volume_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class MetaVolumeApi(object):
         """Deletes a single MetaVolume  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_meta_volume_with_http_info(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_meta_volume_with_http_info(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: None
@@ -173,7 +173,7 @@ class MetaVolumeApi(object):
         """
 
         all_params = ['cluster_name', 'name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -225,7 +225,7 @@ class MetaVolumeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -235,11 +235,11 @@ class MetaVolumeApi(object):
         """Returns a single MetaVolume by name  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_meta_volume(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_meta_volume(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
@@ -248,7 +248,7 @@ class MetaVolumeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_meta_volume_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_meta_volume_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
@@ -258,11 +258,11 @@ class MetaVolumeApi(object):
         """Returns a single MetaVolume by name  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_meta_volume_with_http_info(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_meta_volume_with_http_info(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
@@ -272,7 +272,7 @@ class MetaVolumeApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -326,7 +326,7 @@ class MetaVolumeApi(object):
             files=local_var_files,
             response_type='MetaVolume',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -336,11 +336,11 @@ class MetaVolumeApi(object):
         """Returns a list of MetaVolume objects. Supports paging  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_meta_volumes(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_meta_volumes(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: Filter results by name. See LexicalQueryExpression for details.
         :param str health_state: Filter results by health_state. See LexicalQueryExpression for details.
@@ -354,7 +354,7 @@ class MetaVolumeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_meta_volumes_with_http_info(cluster_name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_meta_volumes_with_http_info(cluster_name, **kwargs)  # noqa: E501
@@ -364,11 +364,11 @@ class MetaVolumeApi(object):
         """Returns a list of MetaVolume objects. Supports paging  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_meta_volumes_with_http_info(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_meta_volumes_with_http_info(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: Filter results by name. See LexicalQueryExpression for details.
         :param str health_state: Filter results by health_state. See LexicalQueryExpression for details.
@@ -383,7 +383,7 @@ class MetaVolumeApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'health_state', 'operational_status', 'offset', 'limit', 'sort_by', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -449,7 +449,7 @@ class MetaVolumeApi(object):
             files=local_var_files,
             response_type='list[MetaVolume]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -460,11 +460,11 @@ class MetaVolumeApi(object):
 
         Settable attributes: 'active' . NOTE: only true value is allowed      # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_meta_volume(cluster_name, name, meta_volume_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_meta_volume(cluster_name, name, meta_volume_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param list[JsonPatchOp] meta_volume_patch_payload: (required)
@@ -473,7 +473,7 @@ class MetaVolumeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.patch_meta_volume_with_http_info(cluster_name, name, meta_volume_patch_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.patch_meta_volume_with_http_info(cluster_name, name, meta_volume_patch_payload, **kwargs)  # noqa: E501
@@ -484,11 +484,11 @@ class MetaVolumeApi(object):
 
         Settable attributes: 'active' . NOTE: only true value is allowed      # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_meta_volume_with_http_info(cluster_name, name, meta_volume_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_meta_volume_with_http_info(cluster_name, name, meta_volume_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param list[JsonPatchOp] meta_volume_patch_payload: (required)
@@ -498,7 +498,7 @@ class MetaVolumeApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'meta_volume_patch_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -556,7 +556,7 @@ class MetaVolumeApi(object):
             files=local_var_files,
             response_type='MetaVolume',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/metadata_backup_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/metadata_backup_api.py
@@ -37,11 +37,11 @@ class MetadataBackupApi(object):
         """Create List of configured MetaData Backups Volume with their scheduled time  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_backup_metadata(cluster_name, metadata_backup_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.create_backup_metadata(cluster_name, metadata_backup_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param MetadataBackupPayload metadata_backup_payload: (required)
         :param str x_include_object: When passed as part of a POST request, controls whether the representation of the newly created object is included in the response. Defaults to 'true' which will include the object in the response. This header is useful because refreshing the newly created object is usually the slowest part of a POST operation. 
@@ -50,7 +50,7 @@ class MetadataBackupApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.create_backup_metadata_with_http_info(cluster_name, metadata_backup_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.create_backup_metadata_with_http_info(cluster_name, metadata_backup_payload, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class MetadataBackupApi(object):
         """Create List of configured MetaData Backups Volume with their scheduled time  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_backup_metadata_with_http_info(cluster_name, metadata_backup_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.create_backup_metadata_with_http_info(cluster_name, metadata_backup_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param MetadataBackupPayload metadata_backup_payload: (required)
         :param str x_include_object: When passed as part of a POST request, controls whether the representation of the newly created object is included in the response. Defaults to 'true' which will include the object in the response. This header is useful because refreshing the newly created object is usually the slowest part of a POST operation. 
@@ -74,7 +74,7 @@ class MetadataBackupApi(object):
         """
 
         all_params = ['cluster_name', 'metadata_backup_payload', 'x_include_object']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -128,7 +128,7 @@ class MetadataBackupApi(object):
             files=local_var_files,
             response_type='InlineResponse201',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -138,18 +138,18 @@ class MetadataBackupApi(object):
         """Delete configured Metadata backup settings  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_backup_metadata(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_backup_metadata(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.delete_backup_metadata_with_http_info(cluster_name, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_backup_metadata_with_http_info(cluster_name, **kwargs)  # noqa: E501
@@ -159,11 +159,11 @@ class MetadataBackupApi(object):
         """Delete configured Metadata backup settings  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_backup_metadata_with_http_info(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_backup_metadata_with_http_info(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :return: None
                  If the method is called asynchronously,
@@ -171,7 +171,7 @@ class MetadataBackupApi(object):
         """
 
         all_params = ['cluster_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -217,7 +217,7 @@ class MetadataBackupApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -227,18 +227,18 @@ class MetadataBackupApi(object):
         """List the configured MetaData Backup settings  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_backup_metadata(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_backup_metadata(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :return: InlineResponse2001
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_backup_metadata_with_http_info(cluster_name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_backup_metadata_with_http_info(cluster_name, **kwargs)  # noqa: E501
@@ -248,11 +248,11 @@ class MetadataBackupApi(object):
         """List the configured MetaData Backup settings  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_backup_metadata_with_http_info(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_backup_metadata_with_http_info(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :return: InlineResponse2001
                  If the method is called asynchronously,
@@ -260,7 +260,7 @@ class MetadataBackupApi(object):
         """
 
         all_params = ['cluster_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -306,7 +306,7 @@ class MetadataBackupApi(object):
             files=local_var_files,
             response_type='InlineResponse2001',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/monitors_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/monitors_api.py
@@ -37,11 +37,11 @@ class MonitorsApi(object):
         """Return performance stats for the given perf monitor.  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_monitor_stats(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_monitor_stats(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
@@ -50,7 +50,7 @@ class MonitorsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_monitor_stats_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_monitor_stats_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class MonitorsApi(object):
         """Return performance stats for the given perf monitor.  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_monitor_stats_with_http_info(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_monitor_stats_with_http_info(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
@@ -74,7 +74,7 @@ class MonitorsApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -128,7 +128,7 @@ class MonitorsApi(object):
             files=local_var_files,
             response_type='Monitors',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -138,11 +138,11 @@ class MonitorsApi(object):
         """Return the list of names of active performance monitors  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_monitors(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_monitors(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
         :param int limit: <p>Maximum number of elements to include in paginated results.<br> <b>'offset' must also be specified.<b>
@@ -153,7 +153,7 @@ class MonitorsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_monitors_with_http_info(cluster_name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_monitors_with_http_info(cluster_name, **kwargs)  # noqa: E501
@@ -163,11 +163,11 @@ class MonitorsApi(object):
         """Return the list of names of active performance monitors  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_monitors_with_http_info(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_monitors_with_http_info(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
         :param int limit: <p>Maximum number of elements to include in paginated results.<br> <b>'offset' must also be specified.<b>
@@ -179,7 +179,7 @@ class MonitorsApi(object):
         """
 
         all_params = ['cluster_name', 'offset', 'limit', 'sort_by', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -239,7 +239,7 @@ class MonitorsApi(object):
             files=local_var_files,
             response_type='list[str]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -249,11 +249,11 @@ class MonitorsApi(object):
         """Return performance stats for the given vvol monitor.  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_vvol_monitor_stats(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_vvol_monitor_stats(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: Monitors
@@ -261,7 +261,7 @@ class MonitorsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_vvol_monitor_stats_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_vvol_monitor_stats_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
@@ -271,11 +271,11 @@ class MonitorsApi(object):
         """Return performance stats for the given vvol monitor.  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_vvol_monitor_stats_with_http_info(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_vvol_monitor_stats_with_http_info(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: Monitors
@@ -284,7 +284,7 @@ class MonitorsApi(object):
         """
 
         all_params = ['cluster_name', 'name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -336,7 +336,7 @@ class MonitorsApi(object):
             files=local_var_files,
             response_type='Monitors',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -346,18 +346,18 @@ class MonitorsApi(object):
         """Return the list of names of active vvol monitors  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_vvol_monitors(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_vvol_monitors(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :return: list[str]
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_vvol_monitors_with_http_info(cluster_name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_vvol_monitors_with_http_info(cluster_name, **kwargs)  # noqa: E501
@@ -367,11 +367,11 @@ class MonitorsApi(object):
         """Return the list of names of active vvol monitors  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_vvol_monitors_with_http_info(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_vvol_monitors_with_http_info(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :return: list[str]
                  If the method is called asynchronously,
@@ -379,7 +379,7 @@ class MonitorsApi(object):
         """
 
         all_params = ['cluster_name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -425,7 +425,7 @@ class MonitorsApi(object):
             files=local_var_files,
             response_type='list[str]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/permissions_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/permissions_api.py
@@ -37,11 +37,11 @@ class PermissionsApi(object):
         """Returns the Role-Based Authentication configuration  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_permissions(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_permissions(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
         :param int limit: <p>Maximum number of elements to include in paginated results.<br> <b>'offset' must also be specified.<b>
         :param str sort_by: Specify the field priority order and direction for sorting.  See SortingOrderExpression for details. 
@@ -51,7 +51,7 @@ class PermissionsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_permissions_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_permissions_with_http_info(**kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class PermissionsApi(object):
         """Returns the Role-Based Authentication configuration  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_permissions_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_permissions_with_http_info(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
         :param int limit: <p>Maximum number of elements to include in paginated results.<br> <b>'offset' must also be specified.<b>
         :param str sort_by: Specify the field priority order and direction for sorting.  See SortingOrderExpression for details. 
@@ -76,7 +76,7 @@ class PermissionsApi(object):
         """
 
         all_params = ['offset', 'limit', 'sort_by', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -130,7 +130,7 @@ class PermissionsApi(object):
             files=local_var_files,
             response_type='list[Permission]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -140,11 +140,11 @@ class PermissionsApi(object):
         """Return the Role-Based Authentication configuration for one role  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_role(rbac_role, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_role(rbac_role, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str rbac_role: The name of the role (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
         :return: Permission
@@ -152,7 +152,7 @@ class PermissionsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_role_with_http_info(rbac_role, **kwargs)  # noqa: E501
         else:
             (data) = self.get_role_with_http_info(rbac_role, **kwargs)  # noqa: E501
@@ -162,11 +162,11 @@ class PermissionsApi(object):
         """Return the Role-Based Authentication configuration for one role  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_role_with_http_info(rbac_role, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_role_with_http_info(rbac_role, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str rbac_role: The name of the role (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
         :return: Permission
@@ -175,7 +175,7 @@ class PermissionsApi(object):
         """
 
         all_params = ['rbac_role', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -223,7 +223,7 @@ class PermissionsApi(object):
             files=local_var_files,
             response_type='Permission',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -234,11 +234,11 @@ class PermissionsApi(object):
 
         To add/remove a path pattern rule, use an add/remove patch with path \"/\" and value \"/path/pattern\".  A new path pattern rule is created with all verbs forbidden.  To permit/forbid a verb at an existing path pattern, use an add/remove patch with path \"/path/pattern\" and value \"verb\".   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_permissions(rbac_role, permission_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_permissions(rbac_role, permission_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str rbac_role: The name of the role (required)
         :param list[JsonPatchOp] permission_patch_payload: (required)
         :return: Permission
@@ -246,7 +246,7 @@ class PermissionsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.patch_permissions_with_http_info(rbac_role, permission_patch_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.patch_permissions_with_http_info(rbac_role, permission_patch_payload, **kwargs)  # noqa: E501
@@ -257,11 +257,11 @@ class PermissionsApi(object):
 
         To add/remove a path pattern rule, use an add/remove patch with path \"/\" and value \"/path/pattern\".  A new path pattern rule is created with all verbs forbidden.  To permit/forbid a verb at an existing path pattern, use an add/remove patch with path \"/path/pattern\" and value \"verb\".   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_permissions_with_http_info(rbac_role, permission_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_permissions_with_http_info(rbac_role, permission_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str rbac_role: The name of the role (required)
         :param list[JsonPatchOp] permission_patch_payload: (required)
         :return: Permission
@@ -270,7 +270,7 @@ class PermissionsApi(object):
         """
 
         all_params = ['rbac_role', 'permission_patch_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -322,7 +322,7 @@ class PermissionsApi(object):
             files=local_var_files,
             response_type='Permission',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/storage_array_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/storage_array_api.py
@@ -37,11 +37,11 @@ class StorageArrayApi(object):
         """Get the default name mapping for claimable volumes on this array  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_name_mapping(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_name_mapping(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: InlineResponse200
@@ -49,7 +49,7 @@ class StorageArrayApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_name_mapping_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_name_mapping_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
@@ -59,11 +59,11 @@ class StorageArrayApi(object):
         """Get the default name mapping for claimable volumes on this array  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_name_mapping_with_http_info(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_name_mapping_with_http_info(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: InlineResponse200
@@ -72,7 +72,7 @@ class StorageArrayApi(object):
         """
 
         all_params = ['cluster_name', 'name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -124,7 +124,7 @@ class StorageArrayApi(object):
             files=local_var_files,
             response_type='InlineResponse200',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -134,11 +134,11 @@ class StorageArrayApi(object):
         """Returns a single StorageArray by name  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_storage_array(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_storage_array(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
@@ -147,7 +147,7 @@ class StorageArrayApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_storage_array_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_storage_array_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
@@ -157,11 +157,11 @@ class StorageArrayApi(object):
         """Returns a single StorageArray by name  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_storage_array_with_http_info(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_storage_array_with_http_info(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
@@ -171,7 +171,7 @@ class StorageArrayApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -225,7 +225,7 @@ class StorageArrayApi(object):
             files=local_var_files,
             response_type='StorageArray',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -235,11 +235,11 @@ class StorageArrayApi(object):
         """Returns a list of StorageArrays  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_storage_arrays(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_storage_arrays(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: Filter results by name. See LexicalQueryExpression for details.
         :param str logical_unit_count: Filter results by logical_unit_count. See NumericQueryExpression for details.
@@ -253,7 +253,7 @@ class StorageArrayApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_storage_arrays_with_http_info(cluster_name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_storage_arrays_with_http_info(cluster_name, **kwargs)  # noqa: E501
@@ -263,11 +263,11 @@ class StorageArrayApi(object):
         """Returns a list of StorageArrays  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_storage_arrays_with_http_info(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_storage_arrays_with_http_info(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: Filter results by name. See LexicalQueryExpression for details.
         :param str logical_unit_count: Filter results by logical_unit_count. See NumericQueryExpression for details.
@@ -282,7 +282,7 @@ class StorageArrayApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'logical_unit_count', 'connectivity_status', 'offset', 'limit', 'sort_by', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -348,7 +348,7 @@ class StorageArrayApi(object):
             files=local_var_files,
             response_type='list[StorageArray]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -358,11 +358,11 @@ class StorageArrayApi(object):
         """Rediscover LUNs on the array  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.rediscover_storage_array(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.rediscover_storage_array(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: StorageArray
@@ -370,7 +370,7 @@ class StorageArrayApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.rediscover_storage_array_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.rediscover_storage_array_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
@@ -380,11 +380,11 @@ class StorageArrayApi(object):
         """Rediscover LUNs on the array  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.rediscover_storage_array_with_http_info(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.rediscover_storage_array_with_http_info(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: StorageArray
@@ -393,7 +393,7 @@ class StorageArrayApi(object):
         """
 
         all_params = ['cluster_name', 'name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -445,7 +445,7 @@ class StorageArrayApi(object):
             files=local_var_files,
             response_type='StorageArray',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/storage_group_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/storage_group_api.py
@@ -37,11 +37,11 @@ class StorageGroupApi(object):
         """Return details of a given storage group  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_storage_group(cluster_name, storagearray_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_storage_group(cluster_name, storagearray_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str storagearray_name: The name of the storage array (required)
         :param str name: The name of a specific instance of the resource (required)
@@ -51,7 +51,7 @@ class StorageGroupApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_storage_group_with_http_info(cluster_name, storagearray_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_storage_group_with_http_info(cluster_name, storagearray_name, name, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class StorageGroupApi(object):
         """Return details of a given storage group  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_storage_group_with_http_info(cluster_name, storagearray_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_storage_group_with_http_info(cluster_name, storagearray_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str storagearray_name: The name of the storage array (required)
         :param str name: The name of a specific instance of the resource (required)
@@ -76,7 +76,7 @@ class StorageGroupApi(object):
         """
 
         all_params = ['cluster_name', 'storagearray_name', 'name', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -136,7 +136,7 @@ class StorageGroupApi(object):
             files=local_var_files,
             response_type='StorageGroup',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -146,11 +146,11 @@ class StorageGroupApi(object):
         """Return the list storage groups  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_storage_groups(cluster_name, storagearray_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_storage_groups(cluster_name, storagearray_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str storagearray_name: The name of the storage array (required)
         :param str name: Filter results by name. See LexicalQueryExpression for details.
@@ -165,7 +165,7 @@ class StorageGroupApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_storage_groups_with_http_info(cluster_name, storagearray_name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_storage_groups_with_http_info(cluster_name, storagearray_name, **kwargs)  # noqa: E501
@@ -175,11 +175,11 @@ class StorageGroupApi(object):
         """Return the list storage groups  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_storage_groups_with_http_info(cluster_name, storagearray_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_storage_groups_with_http_info(cluster_name, storagearray_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str storagearray_name: The name of the storage array (required)
         :param str name: Filter results by name. See LexicalQueryExpression for details.
@@ -195,7 +195,7 @@ class StorageGroupApi(object):
         """
 
         all_params = ['cluster_name', 'storagearray_name', 'name', 'srp', 'policy', 'offset', 'limit', 'sort_by', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -267,7 +267,7 @@ class StorageGroupApi(object):
             files=local_var_files,
             response_type='list[StorageGroup]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/storage_pool_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/storage_pool_api.py
@@ -37,11 +37,11 @@ class StoragePoolApi(object):
         """Return details of a given storage pool  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_storage_pool(cluster_name, storagearray_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_storage_pool(cluster_name, storagearray_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str storagearray_name: The name of the storage array (required)
         :param str name: The name of a specific instance of the resource (required)
@@ -51,7 +51,7 @@ class StoragePoolApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_storage_pool_with_http_info(cluster_name, storagearray_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_storage_pool_with_http_info(cluster_name, storagearray_name, name, **kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class StoragePoolApi(object):
         """Return details of a given storage pool  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_storage_pool_with_http_info(cluster_name, storagearray_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_storage_pool_with_http_info(cluster_name, storagearray_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str storagearray_name: The name of the storage array (required)
         :param str name: The name of a specific instance of the resource (required)
@@ -76,7 +76,7 @@ class StoragePoolApi(object):
         """
 
         all_params = ['cluster_name', 'storagearray_name', 'name', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -136,7 +136,7 @@ class StoragePoolApi(object):
             files=local_var_files,
             response_type='StoragePool',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -146,11 +146,11 @@ class StoragePoolApi(object):
         """Return the list storage pools  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_storage_pools(cluster_name, storagearray_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_storage_pools(cluster_name, storagearray_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str storagearray_name: The name of the storage array (required)
         :param str name: Filter results by name. See LexicalQueryExpression for details.
@@ -164,7 +164,7 @@ class StoragePoolApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_storage_pools_with_http_info(cluster_name, storagearray_name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_storage_pools_with_http_info(cluster_name, storagearray_name, **kwargs)  # noqa: E501
@@ -174,11 +174,11 @@ class StoragePoolApi(object):
         """Return the list storage pools  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_storage_pools_with_http_info(cluster_name, storagearray_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_storage_pools_with_http_info(cluster_name, storagearray_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str storagearray_name: The name of the storage array (required)
         :param str name: Filter results by name. See LexicalQueryExpression for details.
@@ -193,7 +193,7 @@ class StoragePoolApi(object):
         """
 
         all_params = ['cluster_name', 'storagearray_name', 'name', 'policies', 'offset', 'limit', 'sort_by', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -263,7 +263,7 @@ class StoragePoolApi(object):
             files=local_var_files,
             response_type='list[StoragePool]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/storage_volume_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/storage_volume_api.py
@@ -37,11 +37,11 @@ class StorageVolumeApi(object):
         """Claim a StorageVolume  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.claim_storage_volume(cluster_name, name, claim_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.claim_storage_volume(cluster_name, name, claim_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param ClaimPayload claim_payload: (required)
@@ -50,7 +50,7 @@ class StorageVolumeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.claim_storage_volume_with_http_info(cluster_name, name, claim_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.claim_storage_volume_with_http_info(cluster_name, name, claim_payload, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class StorageVolumeApi(object):
         """Claim a StorageVolume  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.claim_storage_volume_with_http_info(cluster_name, name, claim_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.claim_storage_volume_with_http_info(cluster_name, name, claim_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param ClaimPayload claim_payload: (required)
@@ -74,7 +74,7 @@ class StorageVolumeApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'claim_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -132,7 +132,7 @@ class StorageVolumeApi(object):
             files=local_var_files,
             response_type='StorageVolume',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -142,11 +142,11 @@ class StorageVolumeApi(object):
         """Storage volume is not really missing it will reappear after being forgotten  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.forget_storage_volume(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.forget_storage_volume(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: None
@@ -154,7 +154,7 @@ class StorageVolumeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.forget_storage_volume_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.forget_storage_volume_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
@@ -164,11 +164,11 @@ class StorageVolumeApi(object):
         """Storage volume is not really missing it will reappear after being forgotten  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.forget_storage_volume_with_http_info(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.forget_storage_volume_with_http_info(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: None
@@ -177,7 +177,7 @@ class StorageVolumeApi(object):
         """
 
         all_params = ['cluster_name', 'name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -229,7 +229,7 @@ class StorageVolumeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -239,11 +239,11 @@ class StorageVolumeApi(object):
         """Returns a single StorageVolume by name  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_storage_volume(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_storage_volume(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
@@ -252,7 +252,7 @@ class StorageVolumeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_storage_volume_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_storage_volume_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
@@ -262,11 +262,11 @@ class StorageVolumeApi(object):
         """Returns a single StorageVolume by name  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_storage_volume_with_http_info(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_storage_volume_with_http_info(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
@@ -276,7 +276,7 @@ class StorageVolumeApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -330,7 +330,7 @@ class StorageVolumeApi(object):
             files=local_var_files,
             response_type='StorageVolume',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -340,11 +340,11 @@ class StorageVolumeApi(object):
         """Returns a list of StorageVolume objects. Supports paging  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_storage_volumes(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_storage_volumes(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: Filter results by name. See LexicalQueryExpression for details.
         :param str use: Filter results by use. See LexicalQueryExpression for details.
@@ -366,7 +366,7 @@ class StorageVolumeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_storage_volumes_with_http_info(cluster_name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_storage_volumes_with_http_info(cluster_name, **kwargs)  # noqa: E501
@@ -376,11 +376,11 @@ class StorageVolumeApi(object):
         """Returns a list of StorageVolume objects. Supports paging  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_storage_volumes_with_http_info(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_storage_volumes_with_http_info(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: Filter results by name. See LexicalQueryExpression for details.
         :param str use: Filter results by use. See LexicalQueryExpression for details.
@@ -403,7 +403,7 @@ class StorageVolumeApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'use', 'capacity', 'storage_array_name', 'largest_free_chunk', 'provision_type', 'thin_capable', 'thin_rebuild', 'vendor_specific_name', 'health_state', 'operational_status', 'offset', 'limit', 'sort_by', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -485,7 +485,7 @@ class StorageVolumeApi(object):
             files=local_var_files,
             response_type='list[StorageVolume]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -496,11 +496,11 @@ class StorageVolumeApi(object):
 
         Settable attributes: 'name'and 'thin_rebuild'   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_storage_volume(cluster_name, name, storage_volume_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_storage_volume(cluster_name, name, storage_volume_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param list[JsonPatchOp] storage_volume_patch_payload: (required)
@@ -509,7 +509,7 @@ class StorageVolumeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.patch_storage_volume_with_http_info(cluster_name, name, storage_volume_patch_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.patch_storage_volume_with_http_info(cluster_name, name, storage_volume_patch_payload, **kwargs)  # noqa: E501
@@ -520,11 +520,11 @@ class StorageVolumeApi(object):
 
         Settable attributes: 'name'and 'thin_rebuild'   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_storage_volume_with_http_info(cluster_name, name, storage_volume_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_storage_volume_with_http_info(cluster_name, name, storage_volume_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param list[JsonPatchOp] storage_volume_patch_payload: (required)
@@ -534,7 +534,7 @@ class StorageVolumeApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'storage_volume_patch_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -592,7 +592,7 @@ class StorageVolumeApi(object):
             files=local_var_files,
             response_type='StorageVolume',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -602,11 +602,11 @@ class StorageVolumeApi(object):
         """Unclaim a StorageVolume  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.unclaim_storage_volume(cluster_name, name, unclaim_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.unclaim_storage_volume(cluster_name, name, unclaim_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param UnclaimPayload unclaim_payload: (required)
@@ -616,7 +616,7 @@ class StorageVolumeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.unclaim_storage_volume_with_http_info(cluster_name, name, unclaim_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.unclaim_storage_volume_with_http_info(cluster_name, name, unclaim_payload, **kwargs)  # noqa: E501
@@ -626,11 +626,11 @@ class StorageVolumeApi(object):
         """Unclaim a StorageVolume  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.unclaim_storage_volume_with_http_info(cluster_name, name, unclaim_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.unclaim_storage_volume_with_http_info(cluster_name, name, unclaim_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param UnclaimPayload unclaim_payload: (required)
@@ -641,7 +641,7 @@ class StorageVolumeApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'unclaim_payload', 'x_include_object']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -701,7 +701,7 @@ class StorageVolumeApi(object):
             files=local_var_files,
             response_type='StorageVolume',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/system_config_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/system_config_api.py
@@ -37,17 +37,17 @@ class SystemConfigApi(object):
         """Return the system configuration  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_system_config(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_system_config(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :return: SystemConfig
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_system_config_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_system_config_with_http_info(**kwargs)  # noqa: E501
@@ -57,18 +57,18 @@ class SystemConfigApi(object):
         """Return the system configuration  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_system_config_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_system_config_with_http_info(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :return: SystemConfig
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
         all_params = []  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -108,7 +108,7 @@ class SystemConfigApi(object):
             files=local_var_files,
             response_type='SystemConfig',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/token_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/token_api.py
@@ -37,11 +37,11 @@ class TokenApi(object):
         """URL to authenticate and get back access_token in case of success  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.authenticate(username, password, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.authenticate(username, password, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str username: (required)
         :param str password: (required)
         :param LoginPayload token_payload:
@@ -50,7 +50,7 @@ class TokenApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.authenticate_with_http_info(username, password, **kwargs)  # noqa: E501
         else:
             (data) = self.authenticate_with_http_info(username, password, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class TokenApi(object):
         """URL to authenticate and get back access_token in case of success  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.authenticate_with_http_info(username, password, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.authenticate_with_http_info(username, password, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str username: (required)
         :param str password: (required)
         :param LoginPayload token_payload:
@@ -74,7 +74,7 @@ class TokenApi(object):
         """
 
         all_params = ['username', 'password', 'token_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -128,7 +128,7 @@ class TokenApi(object):
             files=local_var_files,
             response_type='LoginResponse',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -138,17 +138,17 @@ class TokenApi(object):
         """Endpoint to logout and invalidate/delete the token  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.logout(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.logout(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.logout_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.logout_with_http_info(**kwargs)  # noqa: E501
@@ -158,18 +158,18 @@ class TokenApi(object):
         """Endpoint to logout and invalidate/delete the token  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.logout_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.logout_with_http_info(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
         all_params = []  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -209,7 +209,7 @@ class TokenApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/version_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/version_api.py
@@ -37,11 +37,11 @@ class VersionApi(object):
         """Returns a list of versions of the VPLEX components  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_versions(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_versions(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
         :param int limit: <p>Maximum number of elements to include in paginated results.<br> <b>'offset' must also be specified.<b>
         :param str sort_by: Specify the field priority order and direction for sorting.  See SortingOrderExpression for details. 
@@ -51,7 +51,7 @@ class VersionApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_versions_with_http_info(**kwargs)  # noqa: E501
         else:
             (data) = self.get_versions_with_http_info(**kwargs)  # noqa: E501
@@ -61,11 +61,11 @@ class VersionApi(object):
         """Returns a list of versions of the VPLEX components  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_versions_with_http_info(async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_versions_with_http_info(async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param int offset: Index of the first element to include in paginated results.<br> <b>'limit' must also be specified.</b>
         :param int limit: <p>Maximum number of elements to include in paginated results.<br> <b>'offset' must also be specified.<b>
         :param str sort_by: Specify the field priority order and direction for sorting.  See SortingOrderExpression for details. 
@@ -76,7 +76,7 @@ class VersionApi(object):
         """
 
         all_params = ['offset', 'limit', 'sort_by', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -130,7 +130,7 @@ class VersionApi(object):
             files=local_var_files,
             response_type='Versions',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/vplexapi-7.0.0.0/vplexapi/api/virtual_volume_api.py
+++ b/vplexapi-7.0.0.0/vplexapi/api/virtual_volume_api.py
@@ -37,11 +37,11 @@ class VirtualVolumeApi(object):
         """Create a new virtual volume  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_virtual_volume(cluster_name, virtual_volume_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.create_virtual_volume(cluster_name, virtual_volume_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param VirtualVolumePayload virtual_volume_payload: (required)
         :param str x_include_object: When passed as part of a POST request, controls whether the representation of the newly created object is included in the response. Defaults to 'true' which will include the object in the response. This header is useful because refreshing the newly created object is usually the slowest part of a POST operation. 
@@ -50,7 +50,7 @@ class VirtualVolumeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.create_virtual_volume_with_http_info(cluster_name, virtual_volume_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.create_virtual_volume_with_http_info(cluster_name, virtual_volume_payload, **kwargs)  # noqa: E501
@@ -60,11 +60,11 @@ class VirtualVolumeApi(object):
         """Create a new virtual volume  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.create_virtual_volume_with_http_info(cluster_name, virtual_volume_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.create_virtual_volume_with_http_info(cluster_name, virtual_volume_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param VirtualVolumePayload virtual_volume_payload: (required)
         :param str x_include_object: When passed as part of a POST request, controls whether the representation of the newly created object is included in the response. Defaults to 'true' which will include the object in the response. This header is useful because refreshing the newly created object is usually the slowest part of a POST operation. 
@@ -74,7 +74,7 @@ class VirtualVolumeApi(object):
         """
 
         all_params = ['cluster_name', 'virtual_volume_payload', 'x_include_object']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -128,7 +128,7 @@ class VirtualVolumeApi(object):
             files=local_var_files,
             response_type='VirtualVolume',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -138,11 +138,11 @@ class VirtualVolumeApi(object):
         """Deletes a single VirtualVolume  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_virtual_volume(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_virtual_volume(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: None
@@ -150,7 +150,7 @@ class VirtualVolumeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.delete_virtual_volume_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.delete_virtual_volume_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
@@ -160,11 +160,11 @@ class VirtualVolumeApi(object):
         """Deletes a single VirtualVolume  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.delete_virtual_volume_with_http_info(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.delete_virtual_volume_with_http_info(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: None
@@ -173,7 +173,7 @@ class VirtualVolumeApi(object):
         """
 
         all_params = ['cluster_name', 'name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -225,7 +225,7 @@ class VirtualVolumeApi(object):
             files=local_var_files,
             response_type=None,  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -235,11 +235,11 @@ class VirtualVolumeApi(object):
         """Expand the capacity of a VirtualVolume  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.expand_virtual_volume(cluster_name, name, virtual_volume_expand_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.expand_virtual_volume(cluster_name, name, virtual_volume_expand_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param VirtualVolumeExpandPayload virtual_volume_expand_payload: (required)
@@ -248,7 +248,7 @@ class VirtualVolumeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.expand_virtual_volume_with_http_info(cluster_name, name, virtual_volume_expand_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.expand_virtual_volume_with_http_info(cluster_name, name, virtual_volume_expand_payload, **kwargs)  # noqa: E501
@@ -258,11 +258,11 @@ class VirtualVolumeApi(object):
         """Expand the capacity of a VirtualVolume  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.expand_virtual_volume_with_http_info(cluster_name, name, virtual_volume_expand_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.expand_virtual_volume_with_http_info(cluster_name, name, virtual_volume_expand_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param VirtualVolumeExpandPayload virtual_volume_expand_payload: (required)
@@ -272,7 +272,7 @@ class VirtualVolumeApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'virtual_volume_expand_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -330,7 +330,7 @@ class VirtualVolumeApi(object):
             files=local_var_files,
             response_type='VirtualVolume',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -340,11 +340,11 @@ class VirtualVolumeApi(object):
         """Return a VirtualVolume matching the provided name  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_virtual_volume(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_virtual_volume(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
@@ -353,7 +353,7 @@ class VirtualVolumeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_virtual_volume_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_virtual_volume_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
@@ -363,11 +363,11 @@ class VirtualVolumeApi(object):
         """Return a VirtualVolume matching the provided name  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_virtual_volume_with_http_info(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_virtual_volume_with_http_info(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param str fields: Select which fields are included in the response. 'name' is always included. See FieldSelectionExpression for details. 
@@ -377,7 +377,7 @@ class VirtualVolumeApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -431,7 +431,7 @@ class VirtualVolumeApi(object):
             files=local_var_files,
             response_type='VirtualVolume',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -441,11 +441,11 @@ class VirtualVolumeApi(object):
         """Returns a list of virtual volumes  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_virtual_volumes(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_virtual_volumes(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: Filter results by name. See LexicalQueryExpression for details.
         :param str capacity: Filter results by capacity.  See NumericQueryExpression for details.
@@ -464,7 +464,7 @@ class VirtualVolumeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.get_virtual_volumes_with_http_info(cluster_name, **kwargs)  # noqa: E501
         else:
             (data) = self.get_virtual_volumes_with_http_info(cluster_name, **kwargs)  # noqa: E501
@@ -474,11 +474,11 @@ class VirtualVolumeApi(object):
         """Returns a list of virtual volumes  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.get_virtual_volumes_with_http_info(cluster_name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.get_virtual_volumes_with_http_info(cluster_name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: Filter results by name. See LexicalQueryExpression for details.
         :param str capacity: Filter results by capacity.  See NumericQueryExpression for details.
@@ -498,7 +498,7 @@ class VirtualVolumeApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'capacity', 'consistency_group', 'health_state', 'operational_status', 'service_status', 'thin_enabled', 'visibility', 'offset', 'limit', 'sort_by', 'fields']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -574,7 +574,7 @@ class VirtualVolumeApi(object):
             files=local_var_files,
             response_type='list[VirtualVolume]',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -585,11 +585,11 @@ class VirtualVolumeApi(object):
 
         Settable attributes: 'name'   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_virtual_volume(cluster_name, name, virtual_volume_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_virtual_volume(cluster_name, name, virtual_volume_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param list[JsonPatchOp] virtual_volume_patch_payload: (required)
@@ -598,7 +598,7 @@ class VirtualVolumeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.patch_virtual_volume_with_http_info(cluster_name, name, virtual_volume_patch_payload, **kwargs)  # noqa: E501
         else:
             (data) = self.patch_virtual_volume_with_http_info(cluster_name, name, virtual_volume_patch_payload, **kwargs)  # noqa: E501
@@ -609,11 +609,11 @@ class VirtualVolumeApi(object):
 
         Settable attributes: 'name'   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.patch_virtual_volume_with_http_info(cluster_name, name, virtual_volume_patch_payload, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.patch_virtual_volume_with_http_info(cluster_name, name, virtual_volume_patch_payload, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :param list[JsonPatchOp] virtual_volume_patch_payload: (required)
@@ -623,7 +623,7 @@ class VirtualVolumeApi(object):
         """
 
         all_params = ['cluster_name', 'name', 'virtual_volume_patch_payload']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -681,7 +681,7 @@ class VirtualVolumeApi(object):
             files=local_var_files,
             response_type='VirtualVolume',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
@@ -691,11 +691,11 @@ class VirtualVolumeApi(object):
         """cache invalidate on virtual volume  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.virtual_volume_cache_invalidate(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.virtual_volume_cache_invalidate(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: VirtualVolume
@@ -703,7 +703,7 @@ class VirtualVolumeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('async'):
+        if kwargs.get('async_http_request'):
             return self.virtual_volume_cache_invalidate_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
         else:
             (data) = self.virtual_volume_cache_invalidate_with_http_info(cluster_name, name, **kwargs)  # noqa: E501
@@ -713,11 +713,11 @@ class VirtualVolumeApi(object):
         """cache invalidate on virtual volume  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async=True
-        >>> thread = api.virtual_volume_cache_invalidate_with_http_info(cluster_name, name, async=True)
+        asynchronous HTTP request, please pass async_http_request=True
+        >>> thread = api.virtual_volume_cache_invalidate_with_http_info(cluster_name, name, async_http_request=True)
         >>> result = thread.get()
 
-        :param async bool
+        :param async_http_request bool
         :param str cluster_name: The name of the cluster (required)
         :param str name: The name of a specific instance of the resource (required)
         :return: VirtualVolume
@@ -726,7 +726,7 @@ class VirtualVolumeApi(object):
         """
 
         all_params = ['cluster_name', 'name']  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_http_request')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -782,7 +782,7 @@ class VirtualVolumeApi(object):
             files=local_var_files,
             response_type='VirtualVolume',  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_http_request=params.get('async_http_request'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),


### PR DESCRIPTION
'async' is now a reserved word in python 3.8
I just went ahead and replaced all references to 'async' with 'async_http_request', I did see that this variable is used in almost all the classes and that they are auto-generated by the swagger-codegen generator program. 
I'm creating this pull request to show a possible fix to the error I'm getting while trying to run this Ansible collection. My Ansible controller/environment is using python 3.9 and it fails to run due to this new 'async' reserved word. 
Since you are using a code generator, I think is an easier fix for you to rename this variable. 
I did not test this change, I don't have a test VPLEX environment, all I have is production VPLEX engines and I'm not comfortable running this there. 